### PR TITLE
feat: wire shuffle-mcp-server into Talon's container (Phase 2b)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ copilot-mcp/.env
 wazuh-mcp/.env
 velociraptor-mcp/.env
 velociraptor-mcp/api.config.yaml
+shuffle-mcp/.env
+shuffle-mcp/.venv/
 
 # Temp files
 .tmp-*

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -54,6 +54,17 @@ RUN python3 -m venv /opt/velociraptor-mcp \
     && /opt/velociraptor-mcp/bin/pip install --quiet \
        "git+https://github.com/socfortress/velociraptor-mcp-server.git"
 
+# Install shuffle-mcp-server into a system venv (used by the Shuffle MCP wrapper)
+# Gives the agent interactive access to Shuffle's 3,000+ apps catalog —
+# RunAppAgentTool / GetExecutionResultTool for natural-language driving of
+# any authenticated app, plus AuthenticateTool / GetAppsTool for discovery.
+# This is separate from CoPilot's notification-dispatch path: that's a
+# fire-and-record server-to-server call; this is for mid-investigation
+# tool use (e.g. "look up this user's email via Outlook search").
+RUN python3 -m venv /opt/shuffle-mcp \
+    && /opt/shuffle-mcp/bin/pip install --quiet \
+       "git+https://github.com/socfortress/shuffle-mcp-server.git"
+
 # Install mempalace + chromadb into a system venv (used by the MemPalace MCP wrapper)
 # chromadb is large — this layer is cached after the first build
 RUN python3 -m venv /opt/mempalace \

--- a/groups/copilot/.mcp.json
+++ b/groups/copilot/.mcp.json
@@ -23,6 +23,9 @@
     },
     "mempalace": {
       "command": "/workspace/extra/mempalace/mempalace-mcp.sh"
+    },
+    "shuffle": {
+      "command": "/workspace/extra/shuffle-mcp/shuffle-mcp.sh"
     }
   }
 }

--- a/groups/copilot/CLAUDE.md
+++ b/groups/copilot/CLAUDE.md
@@ -514,6 +514,11 @@ investigation if dispatch errors. Full instructions: `notifications.md`
   - `CollectArtifactDetailsTool` / `FindArtifactDetailsTool` — get artifact spec and parameters before collecting
   - `CollectArtifactTool` — initiate an artifact collection on a client (returns flow ID)
   - `GetCollectionResultsTool` — retrieve results for a completed collection (includes retry logic)
+- `mcp__shuffle__*` — Shuffle's hosted catalog of 3,000+ SaaS integrations. Use for **interactive** mid-investigation tool calls (e.g. "search Outlook for this user's mailbox," "post a Slack thread to #soc," "open a Jira ticket"). For post-investigation notification fan-out use `mcp__copilot__DispatchNotificationsTool` instead — that path goes through CoPilot's routing engine.
+  - `AuthenticateTool` — verify the Shuffle API key + report active org scope
+  - `GetAppsTool` — list every Shuffle app the key has access to (including the customer's authenticated apps in their org)
+  - `RunAppAgentTool` — kick off an AI-agent run scoped to one app with natural-language `input_text`. Returns `execution_id` + `authorization` for polling.
+  - `GetExecutionResultTool` — poll for a run's terminal state (`FINISHED`, `ABORTED`, etc.). Async pattern — call after `RunAppAgentTool` and re-poll until status settles.
 - `WebSearch`, `WebFetch` — VirusTotal, Shodan, AbuseIPDB, MITRE ATT&CK, threat intel lookups
 - `Bash` — data processing, scripting (sandboxed in this container)
 - `mcp__nanoclaw__schedule_task` — schedule recurring sweeps and monitoring tasks

--- a/shuffle-mcp/.env.example
+++ b/shuffle-mcp/.env.example
@@ -1,0 +1,31 @@
+# Shuffle MCP Server credentials — copy this to .env and fill in your values
+
+# Base URL of your Shuffle backend. Cloud users use https://shuffler.io;
+# self-hosted users use their own region/instance.
+SHUFFLE_URL=https://shuffler.io
+
+# Shuffle API key — sent as `Authorization: Bearer <APIKEY>`.
+# This is the SAME key configured in CoPilot's Shuffle connector row
+# (admin-scoped key with access to every org Talon needs to query).
+# Generate from Shuffle's profile page: /admin?tab=users → API key.
+SHUFFLE_API_KEY=your-shuffle-api-key
+
+# Optional: scope every Shuffle call to one organization. Leave empty
+# for cross-org access (Talon's typical case — investigations span the
+# whole MSP deployment). Set this only if you want a single-tenant
+# Talon group that should never see other orgs.
+SHUFFLE_ORG_ID=
+
+# Verify TLS certificates. Set to "false" for self-signed certs.
+SHUFFLE_SSL_VERIFY=true
+
+# Request timeout in seconds (default: 30).
+SHUFFLE_TIMEOUT=30
+
+# Logging level — DEBUG | INFO | WARNING | ERROR | CRITICAL.
+# Logs go to stderr; stdout is reserved for MCP JSON-RPC.
+LOG_LEVEL=INFO
+
+# Optional: comma-separated list of tool names to disable. Leave empty
+# to expose every tool the server registers.
+SHUFFLE_DISABLED_TOOLS=

--- a/shuffle-mcp/setup.sh
+++ b/shuffle-mcp/setup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# NanoClaw Shuffle MCP — one-time setup
+#
+# What this does:
+#   1. Creates a Python virtual environment (.venv/) to avoid host Python conflicts
+#   2. Installs shuffle-mcp-server from GitHub into it
+#   3. Creates .env from .env.example if not already present
+#
+# After running this, edit .env with your Shuffle API key, then restart NanoClaw.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/.venv"
+ENV_FILE="$SCRIPT_DIR/.env"
+MCP_WRAPPER="$SCRIPT_DIR/shuffle-mcp.sh"
+
+echo "=== NanoClaw Shuffle MCP Setup ==="
+echo ""
+
+# ── Python check ─────────────────────────────────────────────────────────────
+PYTHON_BIN=""
+for candidate in python3.13 python3.12 python3.11 python3.10 python3; do
+    if command -v "$candidate" &>/dev/null; then
+        ver=$("$candidate" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        major=$(echo "$ver" | cut -d. -f1)
+        minor=$(echo "$ver" | cut -d. -f2)
+        if [[ "$major" -eq 3 && "$minor" -ge 10 && "$minor" -le 13 ]]; then
+            PYTHON_BIN="$candidate"
+            PYTHON_VERSION="$ver"
+            break
+        fi
+    fi
+done
+
+if [[ -z "$PYTHON_BIN" ]]; then
+    echo "ERROR: Python 3.10–3.13 is required."
+    echo "       Install Python 3.13 via Homebrew: brew install python@3.13"
+    exit 1
+fi
+
+echo "Using $PYTHON_BIN ($PYTHON_VERSION)  ✓"
+
+# ── Virtual environment ───────────────────────────────────────────────────────
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "Creating virtual environment..."
+    "$PYTHON_BIN" -m venv "$VENV_DIR"
+else
+    echo "Virtual environment exists  ✓"
+fi
+
+# ── Install shuffle-mcp-server ────────────────────────────────────────────────
+echo "Installing shuffle-mcp-server from GitHub..."
+"$VENV_DIR/bin/pip" install --quiet --upgrade pip
+"$VENV_DIR/bin/pip" install --quiet \
+    "git+https://github.com/socfortress/shuffle-mcp-server.git"
+echo "shuffle-mcp-server installed  ✓"
+
+# ── .env ─────────────────────────────────────────────────────────────────────
+if [[ ! -f "$ENV_FILE" ]]; then
+    cp "$SCRIPT_DIR/.env.example" "$ENV_FILE"
+    echo ""
+    echo "  Created .env from template."
+    echo "  ➜ Edit $ENV_FILE with your Shuffle API key."
+    echo ""
+else
+    echo ".env exists  ✓"
+fi
+
+chmod +x "$MCP_WRAPPER"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Setup complete! ==="
+echo ""
+if grep -q "your-shuffle-api-key" "$ENV_FILE" 2>/dev/null; then
+    echo "Next steps:"
+    echo "  1. Edit shuffle-mcp/.env with your Shuffle API key"
+    echo "     (the same key configured in CoPilot's Shuffle connector)"
+    echo "  2. Optionally set SHUFFLE_ORG_ID to scope to one customer's org"
+    echo "  3. Restart NanoClaw"
+else
+    echo "Restart NanoClaw to pick up the Shuffle MCP server."
+fi
+echo ""

--- a/shuffle-mcp/shuffle-mcp.sh
+++ b/shuffle-mcp/shuffle-mcp.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Shuffle MCP Server wrapper for NanoClaw
+#
+# - Loads credentials from .env in the same directory
+# - Runs shuffle-mcp-server from the local .venv (host) or the system
+#   venv pre-installed inside the container image
+#
+# This script is called by Claude Code as the MCP server command.
+# Do not run it directly — use setup.sh first, then start NanoClaw.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load credentials from .env
+if [[ -f "$SCRIPT_DIR/.env" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/.env"
+    set +a
+else
+    echo "[shuffle-mcp] ERROR: .env not found at $SCRIPT_DIR/.env" >&2
+    echo "[shuffle-mcp] Run setup.sh first and fill in your Shuffle credentials." >&2
+    exit 1
+fi
+
+LOCAL_MCP="$SCRIPT_DIR/.venv/bin/shuffle-mcp-server"
+SYSTEM_MCP="/opt/shuffle-mcp/bin/shuffle-mcp-server"
+
+# Check if the local .venv binary is native to this OS (handles macOS venv mounted in Linux container)
+_is_native_exec() {
+    local bin="$1"
+    [[ -x "$bin" ]] || return 1
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        # Verify ELF magic bytes — macOS Mach-O binaries cannot run on Linux
+        local magic
+        magic=$(head -c 4 "$bin" 2>/dev/null | od -An -tx1 | tr -d ' \n')
+        [[ "$magic" == "7f454c46" ]] || return 1
+    fi
+    return 0
+}
+
+if _is_native_exec "$LOCAL_MCP"; then
+    exec "$LOCAL_MCP"
+elif [[ -x "$SYSTEM_MCP" ]]; then
+    # System installation pre-installed in the NanoClaw container image
+    exec "$SYSTEM_MCP"
+else
+    echo "[shuffle-mcp] ERROR: shuffle-mcp-server not found." >&2
+    echo "[shuffle-mcp]   In a container: rebuild the image (container/build.sh)" >&2
+    echo "[shuffle-mcp]   On the host: run shuffle-mcp/setup.sh" >&2
+    exit 1
+fi

--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -225,6 +225,11 @@ export class HttpChannel implements Channel {
             containerPath: 'mempalace-data',
             readonly: false,
           },
+          {
+            hostPath: path.join(process.cwd(), 'shuffle-mcp'),
+            containerPath: 'shuffle-mcp',
+            readonly: true,
+          },
         ],
       },
     };


### PR DESCRIPTION
Phase 2b of the Shuffle integration plan. CoPilot's notification-dispatch path (Phase 2a, already merged) is server-to-server fire-and-record. This is the orthogonal path — **interactive** use of Shuffle's catalog *during* an investigation.

Different concern, different transport (stdio MCP vs HTTPS), different consumer. Both can coexist on the same Shuffle deployment.

## What lands

| File | Change |
|------|--------|
| `shuffle-mcp/shuffle-mcp.sh` + `setup.sh` + `.env.example` | Host-side bundle mirroring `copilot-mcp/` and `wazuh-mcp/` patterns |
| `container/Dockerfile` | Pre-install `shuffle-mcp-server` from GitHub into `/opt/shuffle-mcp` |
| `src/channels/http.ts` | Add `shuffle-mcp/` to copilot group's `additionalMounts` → mounted at `/workspace/extra/shuffle-mcp` |
| `groups/copilot/.mcp.json` | Register `shuffle` server |
| `groups/copilot/CLAUDE.md` | Add `mcp__shuffle__*` to Capabilities section + interactive-vs-dispatch split |
| `.gitignore` | Allowlist `shuffle-mcp/.env` and `shuffle-mcp/.venv/` |

## Deploy steps

1. Pull this branch + merge
2. Either: rebuild container (`./container/build.sh`) for system-venv install, **or** run `shuffle-mcp/setup.sh` on the host
3. Edit `shuffle-mcp/.env` with the Shuffle API key (same key already in CoPilot's connector)
4. Restart Talon
5. Next investigation should load `mcp__shuffle__*` tools — verify with the agent-runner log line `Loaded group MCP servers: ..., shuffle`

## Smoke test

Ask Talon something like "list the Shuffle apps available for customer 00001's org" — agent should call `mcp__shuffle__GetAppsTool` and return the catalog. Then "run a Slack message via Shuffle to #soc-test" — agent picks the Slack app id, calls `RunAppAgentTool` with natural-language input, then polls `GetExecutionResultTool` for terminal state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)