### PR TITLE
feat(providers): swappable Ollama provider + air-gapped Talon support

### DIFF
--- a/.env.provider.example
+++ b/.env.provider.example
@@ -1,0 +1,47 @@
+# =============================================================================
+# Talon agent provider — instance-wide defaults
+# =============================================================================
+#
+# Most Talon installs are single-tenant: pick ONE provider for the whole
+# instance via these vars. Per-customer overrides live in
+# `groups/<group>/container.json` (rarely needed; see *.example files there).
+#
+# Restart Talon after changing these values. They're read at module init.
+#
+# -----------------------------------------------------------------------------
+# Default mode (Anthropic via OneCLI gateway)
+# -----------------------------------------------------------------------------
+# Leave commented or set TALON_PROVIDER=anthropic. OneCLI handles auth —
+# no other config needed.
+#
+# TALON_PROVIDER=anthropic
+
+# -----------------------------------------------------------------------------
+# Air-gapped / fully-local mode (Ollama)
+# -----------------------------------------------------------------------------
+# Talon redirects the Claude SDK at the Ollama endpoint via
+# ANTHROPIC_BASE_URL. Ollama 0.4+ speaks the Anthropic v1/messages API
+# natively, so no provider-side code change is needed. Confirmed
+# tool-calling models: llama3.1, llama3.2, llama3.3, qwen2.5 (non-coder),
+# mistral-nemo. Avoid *-coder variants — broken tool templates.
+#
+# When TALON_PROVIDER=ollama, the container-runner:
+#   1. Skips OneCLI gateway (no upstream secrets to inject).
+#   2. Injects ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN env vars.
+#   3. Sets NO_PROXY for the Ollama host.
+#   4. Upserts `model` into per-group .claude/settings.json.
+#   5. Routes api.anthropic.com to 127.0.0.1 to fail-closed on escape attempts.
+#
+# TALON_PROVIDER=ollama
+# TALON_OLLAMA_BASE_URL=https://qggwu1g2nyt6dw-11434.proxy.runpod.net
+# TALON_OLLAMA_MODEL=llama3.2:latest
+# TALON_OLLAMA_API_KEY=ollama
+
+# -----------------------------------------------------------------------------
+# Optional: extra hosts to block (comma-separated)
+# -----------------------------------------------------------------------------
+# Routes hostnames to 127.0.0.1 inside every container. Useful for
+# defense-in-depth in air-gapped deployments — even if the agent finds an
+# alternate way to reach a third-party LLM API, DNS fails closed.
+#
+# TALON_BLOCKED_HOSTS=api.openai.com,generativelanguage.googleapis.com

--- a/container/agent-runner/src/db/connection.ts
+++ b/container/agent-runner/src/db/connection.ts
@@ -1,0 +1,21 @@
+// Spike-only stub for the v2 container_state watchdog tracking.
+//
+// Upstream nanoclaw v2 introduced a two-DB session model where the
+// agent-runner records "which tool is currently in-flight" so the host
+// watchdog UI can show progress + kill stuck tools. Talon doesn't have
+// that UI surface (we're a headless HTTP service driven by CoPilot)
+// and our existing logging already captures tool start/end events.
+//
+// During the provider-abstraction spike, claude.ts imports these
+// functions from `../db/connection.js`. Rather than pull in the full
+// v2 DB schema, we stub them as no-ops. If we ever add a Talon-side
+// equivalent (e.g. exposing tool state via /status endpoint for
+// CoPilot to poll), wire real logic in here.
+
+export function setContainerToolInFlight(_toolName: string, _declaredTimeoutMs: number | null): void {
+  // intentional no-op for the spike
+}
+
+export function clearContainerToolInFlight(): void {
+  // intentional no-op for the spike
+}

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -1,0 +1,336 @@
+import fs from 'fs';
+import path from 'path';
+
+import { query as sdkQuery, type HookCallback, type PreCompactHookInput } from '@anthropic-ai/claude-agent-sdk';
+
+import { clearContainerToolInFlight, setContainerToolInFlight } from '../db/connection.js';
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, McpServerConfig, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+
+function log(msg: string): void {
+  console.error(`[claude-provider] ${msg}`);
+}
+
+// Deferred SDK builtins that either sidestep nanoclaw's own scheduling or
+// don't fit our async message-passing model (they're designed for Claude
+// Code's interactive UI and would hang here).
+//
+// - CronCreate / CronDelete / CronList / ScheduleWakeup: we have durable
+//   scheduling via mcp__nanoclaw__schedule_task.
+// - AskUserQuestion: SDK returns a placeholder instead of blocking on a
+//   real answer — we have mcp__nanoclaw__ask_user_question that persists
+//   the question and blocks on the real reply.
+// - EnterPlanMode / ExitPlanMode / EnterWorktree / ExitWorktree: Claude
+//   Code UI affordances; in a headless container they'd appear stuck.
+const SDK_DISALLOWED_TOOLS = [
+  'CronCreate',
+  'CronDelete',
+  'CronList',
+  'ScheduleWakeup',
+  'AskUserQuestion',
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'EnterWorktree',
+  'ExitWorktree',
+];
+
+// Tool allowlist for NanoClaw agent containers
+const TOOL_ALLOWLIST = [
+  'Bash',
+  'Read',
+  'Write',
+  'Edit',
+  'Glob',
+  'Grep',
+  'WebSearch',
+  'WebFetch',
+  'Task',
+  'TaskOutput',
+  'TaskStop',
+  'TeamCreate',
+  'TeamDelete',
+  'SendMessage',
+  'TodoWrite',
+  'ToolSearch',
+  'Skill',
+  'NotebookEdit',
+  'mcp__nanoclaw__*',
+];
+
+interface SDKUserMessage {
+  type: 'user';
+  message: { role: 'user'; content: string };
+  parent_tool_use_id: null;
+  session_id: string;
+}
+
+/**
+ * Push-based async iterable for streaming user messages to the Claude SDK.
+ */
+class MessageStream {
+  private queue: SDKUserMessage[] = [];
+  private waiting: (() => void) | null = null;
+  private done = false;
+
+  push(text: string): void {
+    this.queue.push({
+      type: 'user',
+      message: { role: 'user', content: text },
+      parent_tool_use_id: null,
+      session_id: '',
+    });
+    this.waiting?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.waiting?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+      if (this.done) return;
+      await new Promise<void>((r) => {
+        this.waiting = r;
+      });
+      this.waiting = null;
+    }
+  }
+}
+
+// ── Transcript archiving (PreCompact hook) ──
+
+interface ParsedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+function parseTranscript(content: string): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'user' && entry.message?.content) {
+        const text = typeof entry.message.content === 'string' ? entry.message.content : entry.message.content.map((c: { text?: string }) => c.text || '').join('');
+        if (text) messages.push({ role: 'user', content: text });
+      } else if (entry.type === 'assistant' && entry.message?.content) {
+        const textParts = entry.message.content.filter((c: { type: string }) => c.type === 'text').map((c: { text: string }) => c.text);
+        const text = textParts.join('');
+        if (text) messages.push({ role: 'assistant', content: text });
+      }
+    } catch {
+      /* skip unparseable lines */
+    }
+  }
+  return messages;
+}
+
+function formatTranscriptMarkdown(messages: ParsedMessage[], title?: string | null, assistantName?: string): string {
+  const now = new Date();
+  const dateStr = now.toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true });
+  const lines = [`# ${title || 'Conversation'}`, '', `Archived: ${dateStr}`, '', '---', ''];
+  for (const msg of messages) {
+    const sender = msg.role === 'user' ? 'User' : assistantName || 'Assistant';
+    const content = msg.content.length > 2000 ? msg.content.slice(0, 2000) + '...' : msg.content;
+    lines.push(`**${sender}**: ${content}`, '');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * PreToolUse hook: record the current tool + its declared timeout so the host
+ * sweep can widen its stuck tolerance while Bash is running a long-declared
+ * script. Defense-in-depth: if SDK_DISALLOWED_TOOLS slips through somehow,
+ * block the call here instead of letting the agent hang.
+ */
+const preToolUseHook: HookCallback = async (input) => {
+  const i = input as { tool_name?: string; tool_input?: Record<string, unknown> };
+  const toolName = i.tool_name ?? '';
+  if (SDK_DISALLOWED_TOOLS.includes(toolName)) {
+    return {
+      decision: 'block',
+      stopReason: `Tool '${toolName}' is not available in this environment — use the nanoclaw equivalent.`,
+    } as unknown as ReturnType<HookCallback>;
+  }
+  // Bash exposes its timeout via the tool_input.timeout field (ms). Any other
+  // tool: no declared timeout.
+  const declaredTimeoutMs =
+    toolName === 'Bash' && typeof i.tool_input?.timeout === 'number' ? (i.tool_input.timeout as number) : null;
+  try {
+    setContainerToolInFlight(toolName, declaredTimeoutMs);
+  } catch (err) {
+    log(`PreToolUse: failed to record container_state: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return { continue: true };
+};
+
+/** Clear in-flight tool on PostToolUse / PostToolUseFailure. */
+const postToolUseHook: HookCallback = async () => {
+  try {
+    clearContainerToolInFlight();
+  } catch (err) {
+    log(`PostToolUse: failed to clear container_state: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return { continue: true };
+};
+
+function createPreCompactHook(assistantName?: string): HookCallback {
+  return async (input) => {
+    const preCompact = input as PreCompactHookInput;
+    const { transcript_path: transcriptPath, session_id: sessionId } = preCompact;
+
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
+      log('No transcript found for archiving');
+      return {};
+    }
+
+    try {
+      const content = fs.readFileSync(transcriptPath, 'utf-8');
+      const messages = parseTranscript(content);
+      if (messages.length === 0) return {};
+
+      // Try to get summary from sessions index
+      let summary: string | undefined;
+      const indexPath = path.join(path.dirname(transcriptPath), 'sessions-index.json');
+      if (fs.existsSync(indexPath)) {
+        try {
+          const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+          summary = index.entries?.find((e: { sessionId: string; summary?: string }) => e.sessionId === sessionId)?.summary;
+        } catch {
+          /* ignore */
+        }
+      }
+
+      const name = summary
+        ? summary.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 50)
+        : `conversation-${new Date().getHours().toString().padStart(2, '0')}${new Date().getMinutes().toString().padStart(2, '0')}`;
+
+      const conversationsDir = '/workspace/agent/conversations';
+      fs.mkdirSync(conversationsDir, { recursive: true });
+      const filename = `${new Date().toISOString().split('T')[0]}-${name}.md`;
+      fs.writeFileSync(path.join(conversationsDir, filename), formatTranscriptMarkdown(messages, summary, assistantName));
+      log(`Archived conversation to ${filename}`);
+    } catch (err) {
+      log(`Failed to archive transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return {};
+  };
+}
+
+// ── Provider ──
+
+/**
+ * Claude Code auto-compacts context at this window (tokens). Kept here so
+ * the generic bootstrap doesn't need to know about Claude-specific env vars.
+ */
+const CLAUDE_CODE_AUTO_COMPACT_WINDOW = '165000';
+
+/**
+ * Stale-session detection. Matches Claude Code's error text when a
+ * resumed session can't be found — missing transcript .jsonl, unknown
+ * session ID, etc.
+ */
+const STALE_SESSION_RE = /no conversation found|ENOENT.*\.jsonl|session.*not found/i;
+
+export class ClaudeProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = true;
+
+  private assistantName?: string;
+  private mcpServers: Record<string, McpServerConfig>;
+  private env: Record<string, string | undefined>;
+  private additionalDirectories?: string[];
+
+  constructor(options: ProviderOptions = {}) {
+    this.assistantName = options.assistantName;
+    this.mcpServers = options.mcpServers ?? {};
+    this.additionalDirectories = options.additionalDirectories;
+    this.env = {
+      ...(options.env ?? {}),
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+    };
+  }
+
+  isSessionInvalid(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return STALE_SESSION_RE.test(msg);
+  }
+
+  query(input: QueryInput): AgentQuery {
+    const stream = new MessageStream();
+    stream.push(input.prompt);
+
+    const instructions = input.systemContext?.instructions;
+
+    const sdkResult = sdkQuery({
+      prompt: stream,
+      options: {
+        cwd: input.cwd,
+        additionalDirectories: this.additionalDirectories,
+        resume: input.continuation,
+        pathToClaudeCodeExecutable: '/pnpm/claude',
+        systemPrompt: instructions ? { type: 'preset' as const, preset: 'claude_code' as const, append: instructions } : undefined,
+        allowedTools: TOOL_ALLOWLIST,
+        disallowedTools: SDK_DISALLOWED_TOOLS,
+        env: this.env,
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        settingSources: ['project', 'user'],
+        mcpServers: this.mcpServers,
+        hooks: {
+          PreToolUse: [{ hooks: [preToolUseHook] }],
+          PostToolUse: [{ hooks: [postToolUseHook] }],
+          PostToolUseFailure: [{ hooks: [postToolUseHook] }],
+          PreCompact: [{ hooks: [createPreCompactHook(this.assistantName)] }],
+        },
+      },
+    });
+
+    let aborted = false;
+
+    async function* translateEvents(): AsyncGenerator<ProviderEvent> {
+      let messageCount = 0;
+      for await (const message of sdkResult) {
+        if (aborted) return;
+        messageCount++;
+
+        // Yield activity for every SDK event so the poll loop knows the agent is working
+        yield { type: 'activity' };
+
+        if (message.type === 'system' && message.subtype === 'init') {
+          yield { type: 'init', continuation: message.session_id };
+        } else if (message.type === 'result') {
+          const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
+          yield { type: 'result', text };
+        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
+          yield { type: 'error', message: 'API retry', retryable: true };
+        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {
+          yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
+        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
+          const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;
+          const detail = meta?.pre_tokens ? ` (${meta.pre_tokens.toLocaleString()} tokens compacted)` : '';
+          yield { type: 'result', text: `Context compacted${detail}.` };
+        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'task_notification') {
+          const tn = message as { summary?: string };
+          yield { type: 'progress', message: tn.summary || 'Task notification' };
+        }
+      }
+      log(`Query completed after ${messageCount} SDK messages`);
+    }
+
+    return {
+      push: (msg) => stream.push(msg),
+      end: () => stream.end(),
+      events: translateEvents(),
+      abort: () => {
+        aborted = true;
+        stream.end();
+      },
+    };
+  }
+}
+
+registerProvider('claude', (opts) => new ClaudeProvider(opts));

--- a/container/agent-runner/src/providers/codex-app-server.ts
+++ b/container/agent-runner/src/providers/codex-app-server.ts
@@ -1,0 +1,393 @@
+/**
+ * Codex app-server JSON-RPC transport primitives.
+ *
+ * Communicates with `codex app-server` over stdio. This module is just the
+ * plumbing — spawn the process, send requests, dispatch responses and
+ * notifications. Higher-level semantics (threads, turns, event translation)
+ * live in codex.ts.
+ *
+ * Kept separate so the transport can be unit-tested without pulling in the
+ * full provider and so any future Codex tooling (e.g. a CLI for manual
+ * debugging) can reuse the same primitives.
+ */
+import fs from 'fs';
+import path from 'path';
+import { spawn, type ChildProcess } from 'child_process';
+import { createInterface, type Interface as ReadlineInterface } from 'readline';
+
+function log(msg: string): void {
+  console.error(`[codex-app-server] ${msg}`);
+}
+
+const INIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Errors from `thread/resume` that indicate the thread ID is unusable —
+ * typically because the app-server has no memory of it (thread transcript
+ * was deleted, server was wiped, ID is from a different codex version).
+ * Only errors matching this pattern trigger silent fallback to a fresh
+ * thread; everything else bubbles up so the caller can decide what to do.
+ *
+ * Shared with `codex.ts`'s `isSessionInvalid` to keep the two detection
+ * paths in sync.
+ */
+export const STALE_THREAD_RE = /thread\s+not\s+found|unknown\s+thread|thread[_\s]id|no such thread/i;
+
+/**
+ * Escape a string for emission inside a TOML basic string (double-quoted).
+ * Handles `"` and `\`. Rejects newlines: basic strings can't contain raw
+ * newlines, and silently converting them to `\n` would mask misconfiguration
+ * (e.g. a secret pasted with a trailing newline). Multiline strings are
+ * unsupported for `config.toml` use here.
+ */
+export function tomlBasicString(value: string): string {
+  if (value.includes('\n') || value.includes('\r')) {
+    throw new Error(
+      `MCP config value contains newline (not supported in config.toml): ${JSON.stringify(value.slice(0, 40))}${value.length > 40 ? '…' : ''}`,
+    );
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+// ── JSON-RPC types ──────────────────────────────────────────────────────────
+
+let nextRequestId = 1;
+
+interface JsonRpcRequest {
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface JsonRpcNotification {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface JsonRpcServerRequest {
+  id: number;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+type JsonRpcMessage = JsonRpcResponse | JsonRpcNotification | JsonRpcServerRequest;
+
+function makeRequest(method: string, params: Record<string, unknown>): JsonRpcRequest {
+  return { id: nextRequestId++, method, params };
+}
+
+function isResponse(msg: JsonRpcMessage): msg is JsonRpcResponse {
+  return 'id' in msg && ('result' in msg || 'error' in msg) && !('method' in msg);
+}
+
+function isServerRequest(msg: JsonRpcMessage): msg is JsonRpcServerRequest {
+  return 'id' in msg && 'method' in msg;
+}
+
+// ── App-server handle ───────────────────────────────────────────────────────
+
+export interface AppServer {
+  process: ChildProcess;
+  readline: ReadlineInterface;
+  pending: Map<number, { resolve: (r: JsonRpcResponse) => void; reject: (e: Error) => void }>;
+  notificationHandlers: ((n: JsonRpcNotification) => void)[];
+  serverRequestHandlers: ((r: JsonRpcServerRequest) => void)[];
+}
+
+export function spawnCodexAppServer(configOverrides: string[] = []): AppServer {
+  const args = ['app-server', '--listen', 'stdio://'];
+  for (const override of configOverrides) args.push('-c', override);
+
+  log(`Spawning: codex ${args.join(' ')}`);
+  const proc = spawn('codex', args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+
+  const rl = createInterface({ input: proc.stdout! });
+
+  const server: AppServer = {
+    process: proc,
+    readline: rl,
+    pending: new Map(),
+    notificationHandlers: [],
+    serverRequestHandlers: [],
+  };
+
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString().trim();
+    if (text) log(`[stderr] ${text}`);
+  });
+
+  rl.on('line', (line: string) => {
+    if (!line.trim()) return;
+    let msg: JsonRpcMessage;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      log(`[parse-error] ${line.slice(0, 200)}`);
+      return;
+    }
+
+    if (isResponse(msg)) {
+      const handler = server.pending.get(msg.id);
+      if (handler) {
+        server.pending.delete(msg.id);
+        handler.resolve(msg);
+      }
+    } else if (isServerRequest(msg)) {
+      for (const h of server.serverRequestHandlers) h(msg);
+    } else if ('method' in msg) {
+      for (const h of server.notificationHandlers) h(msg as JsonRpcNotification);
+    }
+  });
+
+  proc.on('error', (err) => {
+    log(`[process-error] ${err.message}`);
+    for (const [, handler] of server.pending) handler.reject(err);
+    server.pending.clear();
+  });
+
+  proc.on('exit', (code, signal) => {
+    log(`[exit] code=${code} signal=${signal}`);
+    const err = new Error(`Codex app-server exited: code=${code} signal=${signal}`);
+    for (const [, handler] of server.pending) handler.reject(err);
+    server.pending.clear();
+  });
+
+  return server;
+}
+
+export function sendCodexRequest(
+  server: AppServer,
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs = 60_000,
+): Promise<JsonRpcResponse> {
+  const req = makeRequest(method, params);
+  const line = JSON.stringify(req) + '\n';
+
+  return new Promise<JsonRpcResponse>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      server.pending.delete(req.id);
+      reject(new Error(`Timeout waiting for ${method} response (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    server.pending.set(req.id, {
+      resolve: (r) => {
+        clearTimeout(timer);
+        resolve(r);
+      },
+      reject: (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    });
+
+    try {
+      server.process.stdin!.write(line);
+    } catch (err) {
+      clearTimeout(timer);
+      server.pending.delete(req.id);
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}
+
+export function sendCodexResponse(server: AppServer, id: number, result: unknown): void {
+  const line = JSON.stringify({ id, result }) + '\n';
+  try {
+    server.process.stdin!.write(line);
+  } catch (err) {
+    log(`[send-error] Failed to send response for id=${id}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function killCodexAppServer(server: AppServer): void {
+  try {
+    server.readline.close();
+    server.process.kill('SIGTERM');
+  } catch {
+    /* ignore */
+  }
+}
+
+// ── Auto-approval ───────────────────────────────────────────────────────────
+// The container sandbox is already the security boundary; inside it, Codex's
+// own approval prompts would just block every tool call on a user that isn't
+// watching. Accept everything and let sandbox limits do the enforcement.
+
+export function attachCodexAutoApproval(server: AppServer): void {
+  server.serverRequestHandlers.push((req) => {
+    const method = req.method;
+    log(`[approval] ${method}`);
+
+    switch (method) {
+      case 'item/commandExecution/requestApproval':
+      case 'item/fileChange/requestApproval':
+        sendCodexResponse(server, req.id, { decision: 'accept' });
+        break;
+      case 'item/permissions/requestApproval':
+        sendCodexResponse(server, req.id, {
+          permissions: { fileSystem: { read: ['/'], write: ['/'] }, network: { enabled: true } },
+          scope: 'session',
+        });
+        break;
+      case 'applyPatchApproval':
+      case 'execCommandApproval':
+        sendCodexResponse(server, req.id, { decision: 'approved' });
+        break;
+      case 'item/tool/call': {
+        const toolName = (req.params as { tool?: string }).tool || 'unknown';
+        log(`[approval] Unexpected dynamic tool call: ${toolName}`);
+        sendCodexResponse(server, req.id, {
+          success: false,
+          contentItems: [{ type: 'inputText', text: `Tool "${toolName}" is not available. Use MCP tools instead.` }],
+        });
+        break;
+      }
+      case 'item/tool/requestUserInput':
+      case 'mcpServer/elicitation/request':
+        sendCodexResponse(server, req.id, { input: null });
+        break;
+      default:
+        log(`[approval] Unknown method ${method}, generic accept`);
+        sendCodexResponse(server, req.id, { decision: 'accept' });
+        break;
+    }
+  });
+}
+
+// ── High-level helpers ──────────────────────────────────────────────────────
+
+export async function initializeCodexAppServer(server: AppServer): Promise<void> {
+  log('Sending initialize…');
+  const resp = await sendCodexRequest(
+    server,
+    'initialize',
+    {
+      clientInfo: { name: 'nanoclaw', version: '1.0.0' },
+      capabilities: { experimentalApi: false },
+    },
+    INIT_TIMEOUT_MS,
+  );
+  if (resp.error) throw new Error(`Initialize failed: ${resp.error.message}`);
+  log('Initialize successful');
+}
+
+export interface ThreadParams {
+  model: string;
+  cwd: string;
+  sandbox?: string;
+  approvalPolicy?: string;
+  personality?: string;
+  baseInstructions?: string;
+}
+
+/**
+ * Start or resume a Codex thread. If `threadId` is provided, attempts
+ * `thread/resume` first and falls back to a fresh `thread/start` on failure
+ * (stale thread IDs commonly outlive containers). Returns the active thread
+ * ID either way.
+ */
+export async function startOrResumeCodexThread(
+  server: AppServer,
+  threadId: string | undefined,
+  params: ThreadParams,
+): Promise<string> {
+  if (threadId) {
+    log(`Resuming thread: ${threadId}`);
+    const resp = await sendCodexRequest(server, 'thread/resume', {
+      threadId,
+      ...(params as unknown as Record<string, unknown>),
+    });
+    if (!resp.error) {
+      log(`Thread resumed: ${threadId}`);
+      return threadId;
+    }
+    // Only fall through to fresh-thread on recognized stale-thread errors.
+    // Auth, version, or transient failures would otherwise silently discard
+    // session state — fail loud instead so the caller can retry or surface.
+    if (!STALE_THREAD_RE.test(resp.error.message)) {
+      throw new Error(`thread/resume failed: ${resp.error.message}`);
+    }
+    log(`Stale thread ${threadId}; starting fresh thread.`);
+  }
+
+  log('Starting new thread…');
+  const resp = await sendCodexRequest(server, 'thread/start', {
+    ...(params as unknown as Record<string, unknown>),
+  });
+  if (resp.error) throw new Error(`thread/start failed: ${resp.error.message}`);
+
+  const result = resp.result as { thread?: { id?: string } } | undefined;
+  const newThreadId = result?.thread?.id;
+  if (!newThreadId) throw new Error('thread/start response missing thread ID');
+  log(`New thread: ${newThreadId}`);
+  return newThreadId;
+}
+
+export interface TurnParams {
+  threadId: string;
+  inputText: string;
+  model?: string;
+  cwd?: string;
+}
+
+export async function startCodexTurn(server: AppServer, params: TurnParams): Promise<void> {
+  const resp = await sendCodexRequest(server, 'turn/start', {
+    threadId: params.threadId,
+    input: [{ type: 'text', text: params.inputText }],
+    model: params.model,
+    cwd: params.cwd,
+  });
+  if (resp.error) throw new Error(`turn/start failed: ${resp.error.message}`);
+}
+
+// ── MCP config.toml ─────────────────────────────────────────────────────────
+// Codex discovers MCP servers by reading ~/.codex/config.toml at startup.
+// We rewrite it on every spawn from whatever mcpServers the agent-runner
+// passes in, so the container's config reflects the current host wiring.
+
+export interface CodexMcpServer {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export function writeCodexMcpConfigToml(servers: Record<string, CodexMcpServer>): void {
+  const codexConfigDir = path.join(process.env.HOME || '/home/node', '.codex');
+  fs.mkdirSync(codexConfigDir, { recursive: true });
+  const configTomlPath = path.join(codexConfigDir, 'config.toml');
+
+  const lines: string[] = [];
+  for (const [name, config] of Object.entries(servers)) {
+    lines.push(`[mcp_servers.${name}]`);
+    lines.push('type = "stdio"');
+    lines.push(`command = ${tomlBasicString(config.command)}`);
+    if (config.args && config.args.length > 0) {
+      const argsStr = config.args.map(tomlBasicString).join(', ');
+      lines.push(`args = [${argsStr}]`);
+    }
+    if (config.env && Object.keys(config.env).length > 0) {
+      lines.push(`[mcp_servers.${name}.env]`);
+      for (const [key, value] of Object.entries(config.env)) {
+        lines.push(`${key} = ${tomlBasicString(value)}`);
+      }
+    }
+    lines.push('');
+  }
+
+  fs.writeFileSync(configTomlPath, lines.join('\n'));
+  log(`Wrote MCP config.toml (${Object.keys(servers).length} server(s))`);
+}
+
+export function createCodexConfigOverrides(): string[] {
+  return ['features.use_linux_sandbox_bwrap=false'];
+}

--- a/container/agent-runner/src/providers/codex.ts
+++ b/container/agent-runner/src/providers/codex.ts
@@ -1,0 +1,332 @@
+/**
+ * OpenAI Codex provider — wraps `codex app-server` via JSON-RPC.
+ *
+ * Unlike the (deprecated) @openai/codex-sdk approach, the app-server
+ * protocol exposes proper session/stream semantics, native compaction, and
+ * stable MCP config via ~/.codex/config.toml — which is the same mechanism
+ * the standalone codex CLI uses, so the container and host share one
+ * provider-integration story.
+ *
+ * Codex turns don't accept mid-turn input. Follow-up `push()` messages are
+ * queued and drained after the current turn completes (same pattern as the
+ * opencode provider — see poll-loop for why that's correct: the poll-loop
+ * only pushes once it has new pending messages, and we only drain between
+ * turns, so no message is dropped).
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+import {
+  type AppServer,
+  type JsonRpcNotification,
+  STALE_THREAD_RE,
+  attachCodexAutoApproval,
+  createCodexConfigOverrides,
+  initializeCodexAppServer,
+  killCodexAppServer,
+  spawnCodexAppServer,
+  startCodexTurn,
+  startOrResumeCodexThread,
+  writeCodexMcpConfigToml,
+} from './codex-app-server.js';
+
+/** Hard ceiling for a single turn. Guards against app-server wedging. */
+const TURN_TIMEOUT_MS = 5 * 60 * 1000;
+
+// ── System-prompt assembly ──────────────────────────────────────────────────
+// Codex's app-server doesn't expand Claude Code's `@-import` syntax in
+// CLAUDE.md, and doesn't auto-load CLAUDE.local.md from the working dir the
+// way Claude Code does. Left alone, the agent sees only the raw import
+// directives as literal text and none of the composed content — no shared
+// CLAUDE.md, no module fragments, no per-group memory. We resolve both here
+// so Codex (and any other non-Claude provider) gets the same effective
+// system prompt the Claude provider gets natively.
+
+/**
+ * Inline `@<path>` import directives (line-anchored) with the contents of
+ * the referenced file, resolved relative to `baseDir`. Recurses so imports
+ * within imported files expand too. Cycles and missing files are silently
+ * dropped (replaced with empty text) rather than left as raw `@path` lines,
+ * which would confuse the model.
+ */
+export function resolveClaudeImports(content: string, baseDir: string, seen: Set<string> = new Set()): string {
+  return content.replace(/^@(\S+)\s*$/gm, (_match, importPath: string) => {
+    try {
+      const resolved = path.resolve(baseDir, importPath);
+      if (seen.has(resolved)) return '';
+      if (!fs.existsSync(resolved)) return '';
+      const nextSeen = new Set(seen);
+      nextSeen.add(resolved);
+      const imported = fs.readFileSync(resolved, 'utf-8');
+      return resolveClaudeImports(imported, path.dirname(resolved), nextSeen);
+    } catch {
+      return '';
+    }
+  });
+}
+
+function readAgentAndGlobalClaudeMd(): string | undefined {
+  // Per-group CLAUDE.md is responsible for pulling in the global instructions
+  // if the group wants them (the default scaffold starts with
+  // `@./.claude-global.md` which resolveClaudeImports inlines). Appending
+  // `/workspace/global/CLAUDE.md` explicitly here would double-inline the
+  // global content for any non-main group, wasting context tokens and
+  // risking contradictory instructions. Groups that don't import global
+  // intentionally don't get it — same as Claude-backed agents.
+  const groupDir = '/workspace/agent';
+  const groupPath = `${groupDir}/CLAUDE.md`;
+  const localPath = `${groupDir}/CLAUDE.local.md`;
+  const parts: string[] = [];
+
+  if (fs.existsSync(groupPath)) {
+    parts.push(resolveClaudeImports(fs.readFileSync(groupPath, 'utf-8'), groupDir));
+  }
+  if (fs.existsSync(localPath)) {
+    parts.push(resolveClaudeImports(fs.readFileSync(localPath, 'utf-8'), groupDir));
+  }
+
+  return parts.length > 0 ? parts.join('\n\n---\n\n') : undefined;
+}
+
+function composeBaseInstructions(promptAddendum: string | undefined): string | undefined {
+  const claudeMd = readAgentAndGlobalClaudeMd();
+  const pieces = [claudeMd, promptAddendum].filter((s): s is string => Boolean(s));
+  return pieces.length > 0 ? pieces.join('\n\n---\n\n') : undefined;
+}
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+export class CodexProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  private readonly mcpServers: Record<string, { command: string; args: string[]; env: Record<string, string> }>;
+  private readonly model: string;
+
+  constructor(options: ProviderOptions = {}) {
+    this.mcpServers = options.mcpServers ?? {};
+    this.model = (options.env?.CODEX_MODEL as string | undefined) ?? 'gpt-5.4-mini';
+  }
+
+  isSessionInvalid(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return STALE_THREAD_RE.test(msg);
+  }
+
+  query(input: QueryInput): AgentQuery {
+    const pending: string[] = [];
+    let waiting: (() => void) | null = null;
+    let ended = false;
+    let aborted = false;
+    const kick = (): void => {
+      waiting?.();
+    };
+
+    pending.push(input.prompt);
+
+    const self = this;
+
+    async function* gen(): AsyncGenerator<ProviderEvent> {
+      // One app-server per query invocation. The poll-loop keeps a single
+      // query active per batch of pending messages and ends it on idle, so
+      // spawn-per-query matches that cadence naturally.
+      writeCodexMcpConfigToml(self.mcpServers);
+      const server = spawnCodexAppServer(createCodexConfigOverrides());
+      attachCodexAutoApproval(server);
+
+      let threadId: string | undefined = input.continuation;
+      let initYielded = false;
+
+      try {
+        await initializeCodexAppServer(server);
+
+        const threadParams = {
+          model: self.model,
+          cwd: input.cwd,
+          sandbox: 'danger-full-access',
+          approvalPolicy: 'never',
+          personality: 'friendly',
+          baseInstructions: composeBaseInstructions(input.systemContext?.instructions),
+        };
+
+        threadId = await startOrResumeCodexThread(server, threadId, threadParams);
+
+        while (!aborted) {
+          while (pending.length === 0 && !ended && !aborted) {
+            await new Promise<void>((resolve) => {
+              waiting = resolve;
+            });
+            waiting = null;
+          }
+          if (aborted) return;
+          if (pending.length === 0 && ended) return;
+
+          const text = pending.shift()!;
+
+          // One turn = one channel of streaming events. Each notification
+          // from the app-server yields an `activity` first (so the
+          // poll-loop's idle timer stays honest) and then, where relevant,
+          // an init / result / progress event.
+          yield* runOneTurn(
+            server,
+            threadId!,
+            text,
+            self.model,
+            input.cwd,
+            () => initYielded,
+            () => {
+              initYielded = true;
+            },
+          );
+        }
+      } finally {
+        killCodexAppServer(server);
+      }
+    }
+
+    return {
+      push: (message: string) => {
+        pending.push(message);
+        kick();
+      },
+      end: () => {
+        ended = true;
+        kick();
+      },
+      abort: () => {
+        aborted = true;
+        kick();
+      },
+      events: gen(),
+    };
+  }
+}
+
+// ── Per-turn event pump ─────────────────────────────────────────────────────
+// Pulled out because the gen() loop above reads cleaner with it extracted,
+// and because it's a natural seam for future unit tests that drive it with
+// a fake notification stream.
+
+async function* runOneTurn(
+  server: AppServer,
+  threadId: string,
+  inputText: string,
+  model: string,
+  cwd: string,
+  hasInit: () => boolean,
+  markInit: () => void,
+): AsyncGenerator<ProviderEvent> {
+  // Mutable refs via object properties — TS can't track closure assignments
+  // for narrowing, but property access keeps the declared type visible.
+  const turnState: { error: Error | null } = { error: null };
+  let resultText = '';
+  let turnDone = false;
+
+  // Buffered event queue so we can `yield` across the async notification
+  // callback. Each notification pushes zero or more ProviderEvents; the
+  // generator drains the buffer.
+  const buffer: ProviderEvent[] = [];
+  let waker: (() => void) | null = null;
+  const kick = (): void => {
+    waker?.();
+    waker = null;
+  };
+
+  const handler = (n: JsonRpcNotification): void => {
+    const method = n.method;
+    const params = n.params;
+
+    // Every inbound notification counts as activity for the poll-loop's
+    // idle timer — yield before any event-specific translation so even
+    // long tool executions keep the loop awake.
+    buffer.push({ type: 'activity' });
+
+    switch (method) {
+      case 'thread/started': {
+        const thread = params.thread as { id?: string } | undefined;
+        if (thread?.id && !hasInit()) {
+          markInit();
+          buffer.push({ type: 'init', continuation: thread.id });
+        }
+        break;
+      }
+      case 'item/agentMessage/delta': {
+        const delta = params.delta as string;
+        if (delta) resultText += delta;
+        break;
+      }
+      case 'item/completed': {
+        const item = params.item as { type?: string; text?: string } | undefined;
+        if (item?.type === 'agentMessage' && item.text) resultText = item.text;
+        break;
+      }
+      case 'turn/completed':
+        turnDone = true;
+        break;
+      case 'turn/failed': {
+        const e = params.error as { message?: string } | undefined;
+        turnState.error = new Error(e?.message || 'Turn failed');
+        turnDone = true;
+        break;
+      }
+      case 'thread/status/changed': {
+        const status = params.status as string | undefined;
+        if (status) buffer.push({ type: 'progress', message: `status: ${status}` });
+        break;
+      }
+      default:
+        // Silently handle the many item/* notifications — they already
+        // contributed an activity event above.
+        break;
+    }
+
+    kick();
+  };
+
+  server.notificationHandlers.push(handler);
+
+  const timer = setTimeout(() => {
+    turnState.error = new Error(`Turn timed out after ${TURN_TIMEOUT_MS}ms`);
+    turnDone = true;
+    kick();
+  }, TURN_TIMEOUT_MS);
+
+  try {
+    // If we yield init before turn/start, the poll-loop stores
+    // continuation early and survives a mid-turn crash.
+    if (!hasInit()) {
+      markInit();
+      buffer.push({ type: 'init', continuation: threadId });
+    }
+
+    await startCodexTurn(server, { threadId, inputText, model, cwd });
+
+    while (true) {
+      while (buffer.length > 0) {
+        const ev = buffer.shift()!;
+        yield ev;
+      }
+      if (turnDone) break;
+      await new Promise<void>((resolve) => {
+        waker = resolve;
+      });
+      waker = null;
+    }
+
+    while (buffer.length > 0) yield buffer.shift()!;
+
+    if (turnState.error) {
+      yield { type: 'error', message: turnState.error.message, retryable: false };
+      return;
+    }
+
+    yield { type: 'result', text: resultText || null };
+  } finally {
+    clearTimeout(timer);
+    const idx = server.notificationHandlers.indexOf(handler);
+    if (idx >= 0) server.notificationHandlers.splice(idx, 1);
+  }
+}
+
+registerProvider('codex', (opts) => new CodexProvider(opts));

--- a/container/agent-runner/src/providers/factory.ts
+++ b/container/agent-runner/src/providers/factory.ts
@@ -1,0 +1,13 @@
+import type { AgentProvider, ProviderOptions } from './types.js';
+import { getProviderFactory } from './provider-registry.js';
+
+/**
+ * Any registered provider name. Kept as a named alias for readability; the
+ * set of valid names is open and determined at runtime by whichever provider
+ * modules the `providers/index.ts` barrel imports.
+ */
+export type ProviderName = string;
+
+export function createProvider(name: ProviderName, options: ProviderOptions = {}): AgentProvider {
+  return getProviderFactory(name)(options);
+}

--- a/container/agent-runner/src/providers/index.ts
+++ b/container/agent-runner/src/providers/index.ts
@@ -1,0 +1,9 @@
+// Provider self-registration barrel.
+// Each import triggers the provider module's registerProvider() call at top
+// level. Skills add a new provider by appending one import line below.
+
+import './claude.js';
+import './codex.js';
+import './mock.js';
+// opencode.js dropped from this spike — requires @opencode-ai/sdk dep we
+// don't need for the air-gapped use case. Add back when wiring Phase C.

--- a/container/agent-runner/src/providers/mock.ts
+++ b/container/agent-runner/src/providers/mock.ts
@@ -1,0 +1,77 @@
+import { registerProvider } from './provider-registry.js';
+import type { AgentProvider, AgentQuery, ProviderEvent, ProviderOptions, QueryInput } from './types.js';
+
+/**
+ * Mock provider for testing. Returns canned responses.
+ * Supports push() — queued messages produce additional results.
+ */
+export class MockProvider implements AgentProvider {
+  readonly supportsNativeSlashCommands = false;
+
+  private responseFactory: (prompt: string) => string;
+
+  constructor(_options: ProviderOptions = {}, responseFactory?: (prompt: string) => string) {
+    this.responseFactory = responseFactory ?? ((prompt) => `Mock response to: ${prompt.slice(0, 100)}`);
+  }
+
+  isSessionInvalid(_err: unknown): boolean {
+    return false;
+  }
+
+  query(input: QueryInput): AgentQuery {
+    const pending: string[] = [];
+    let waiting: (() => void) | null = null;
+    let ended = false;
+    let aborted = false;
+    const responseFactory = this.responseFactory;
+
+    const events: AsyncIterable<ProviderEvent> = {
+      async *[Symbol.asyncIterator]() {
+        yield { type: 'activity' };
+        yield { type: 'init', continuation: `mock-session-${Date.now()}` };
+
+        // Process initial prompt
+        yield { type: 'activity' };
+        yield { type: 'result', text: responseFactory(input.prompt) };
+
+        // Process any pushed follow-ups
+        while (!ended && !aborted) {
+          if (pending.length > 0) {
+            const msg = pending.shift()!;
+            yield { type: 'result', text: responseFactory(msg) };
+            continue;
+          }
+          // Wait for push() or end()
+          await new Promise<void>((resolve) => {
+            waiting = resolve;
+          });
+          waiting = null;
+        }
+
+        // Drain remaining
+        while (pending.length > 0) {
+          const msg = pending.shift()!;
+          yield { type: 'result', text: responseFactory(msg) };
+        }
+      },
+    };
+
+    return {
+      push(message: string) {
+        pending.push(message);
+        waiting?.();
+      },
+      end() {
+        ended = true;
+        waiting?.();
+      },
+      events,
+      abort() {
+        aborted = true;
+        waiting?.();
+      },
+    };
+  }
+}
+
+registerProvider('mock', (opts) => new MockProvider(opts));

--- a/container/agent-runner/src/providers/provider-registry.ts
+++ b/container/agent-runner/src/providers/provider-registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Provider self-registration registry.
+ *
+ * Mirrors `src/channels/channel-registry.ts` on the host. Each provider module
+ * calls `registerProvider()` at top level; the barrel (`providers/index.ts`)
+ * imports every provider module for its side effect so registrations fire
+ * before `createProvider()` is called.
+ */
+import type { AgentProvider, ProviderOptions } from './types.js';
+
+export type ProviderFactory = (options: ProviderOptions) => AgentProvider;
+
+const registry = new Map<string, ProviderFactory>();
+
+export function registerProvider(name: string, factory: ProviderFactory): void {
+  if (registry.has(name)) {
+    throw new Error(`Provider already registered: ${name}`);
+  }
+  registry.set(name, factory);
+}
+
+export function getProviderFactory(name: string): ProviderFactory {
+  const factory = registry.get(name);
+  if (!factory) {
+    const known = [...registry.keys()].join(', ') || '(none)';
+    throw new Error(`Unknown provider: ${name}. Registered: ${known}`);
+  }
+  return factory;
+}
+
+export function listProviderNames(): string[] {
+  return [...registry.keys()];
+}

--- a/container/agent-runner/src/providers/types.ts
+++ b/container/agent-runner/src/providers/types.ts
@@ -1,0 +1,82 @@
+export interface AgentProvider {
+  /**
+   * True if the provider's underlying SDK handles slash commands natively and
+   * wants them passed through as raw text. When false, the poll-loop formats
+   * slash commands like any other chat message.
+   */
+  readonly supportsNativeSlashCommands: boolean;
+
+  /** Start a new query. Returns a handle for streaming input and output. */
+  query(input: QueryInput): AgentQuery;
+
+  /**
+   * True if the given error indicates the stored continuation is invalid
+   * (missing transcript, unknown session, etc.) and should be cleared.
+   */
+  isSessionInvalid(err: unknown): boolean;
+}
+
+/**
+ * Options passed to provider constructors. Fields are common to most
+ * providers; individual providers may ignore any they don't need.
+ */
+export interface ProviderOptions {
+  assistantName?: string;
+  mcpServers?: Record<string, McpServerConfig>;
+  env?: Record<string, string | undefined>;
+  additionalDirectories?: string[];
+}
+
+export interface QueryInput {
+  /** Initial prompt (already formatted by agent-runner). */
+  prompt: string;
+
+  /**
+   * Opaque continuation token from a previous query. The provider decides
+   * what this means (session ID, thread ID, nothing at all).
+   */
+  continuation?: string;
+
+  /** Working directory inside the container. */
+  cwd: string;
+
+  /**
+   * System context to inject. Providers translate this into whatever their
+   * SDK expects (preset append, full system prompt, per-turn injection…).
+   */
+  systemContext?: {
+    instructions?: string;
+  };
+}
+
+export interface McpServerConfig {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export interface AgentQuery {
+  /** Push a follow-up message into the active query. */
+  push(message: string): void;
+
+  /** Signal that no more input will be sent. */
+  end(): void;
+
+  /** Output event stream. */
+  events: AsyncIterable<ProviderEvent>;
+
+  /** Force-stop the query. */
+  abort(): void;
+}
+
+export type ProviderEvent =
+  | { type: 'init'; continuation: string }
+  | { type: 'result'; text: string | null }
+  | { type: 'error'; message: string; retryable: boolean; classification?: string }
+  | { type: 'progress'; message: string }
+  /**
+   * Liveness signal. Providers MUST yield this on every underlying SDK
+   * event (tool call, thinking, partial message, anything) so the
+   * poll-loop's idle timer stays honest during long tool runs.
+   */
+  | { type: 'activity' };

--- a/docs/PROVIDER_SELECTION.md
+++ b/docs/PROVIDER_SELECTION.md
@@ -1,0 +1,109 @@
+# Agent Provider Selection
+
+Talon supports two agent providers: **Anthropic** (default, cloud) and **Ollama** (fully-local / air-gapped). Switching is `.env`-driven for single-tenant installs, with an optional per-group override for multi-tenant deployments.
+
+## TL;DR
+
+```bash
+# /opt/talon/.env  (or repo root .env in dev)
+
+# Default — Anthropic via OneCLI gateway. Leave unset, no action needed.
+# TALON_PROVIDER=anthropic
+
+# Air-gapped — redirect Claude SDK at a local Ollama instance.
+TALON_PROVIDER=ollama
+TALON_OLLAMA_BASE_URL=http://host.docker.internal:11434
+TALON_OLLAMA_MODEL=llama3.3:70b
+TALON_OLLAMA_API_KEY=ollama   # optional, defaults to "ollama"
+```
+
+Restart Talon. Every group inherits the provider.
+
+## How it works under the hood
+
+Ollama 0.4+ speaks the Anthropic `/v1/messages` API natively. When `TALON_PROVIDER=ollama`, the container-runner:
+
+1. Skips the OneCLI credential gateway (no upstream secrets to inject).
+2. Injects `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` env vars so the Claude Agent SDK redirects to Ollama.
+3. Injects `NO_PROXY` for the Ollama host so any HTTPS_PROXY doesn't intercept the redirect.
+4. Upserts `model` into the per-group `.claude/settings.json` so the SDK picks the local Ollama model.
+5. Routes `api.anthropic.com` to `127.0.0.1` via `--add-host` to fail-closed on escape attempts.
+
+When `TALON_PROVIDER=anthropic` (or unset), none of the above happens — the existing OneCLI gateway path handles authentication.
+
+## Per-group overrides (multi-tenant)
+
+For the rare case where one customer should run a different provider, drop a `container.json` into the group folder. See `docs/provider-examples/`. Per-group settings take precedence over `.env` defaults.
+
+## Model selection
+
+Native long-context models (no YaRN tricks needed):
+
+| Model | Native ctx | Tool reliability | Min VRAM (Q4) |
+|-------|-----------|------------------|----------------|
+| `llama3.1:8b` | 128K | OK for simple flows; struggles on 100+ tool selection | ~6 GB |
+| `qwen2.5:14b-instruct-1m` | 1M | Solid | ~10 GB |
+| `qwen2.5:32b-instruct` | 32K native (no extension) | Reliable, self-corrects schemas | ~25 GB |
+| `llama3.3:70b` | 128K | Best general-purpose, full Claude Code scaffold | ~50-60 GB |
+
+Avoid `*-coder` variants — broken tool templates emit stringified JSON instead of `tool_use` blocks.
+
+## Latency expectations
+
+For the SOC-analyst preset (full Claude Code system prompt + 10 MCP servers + 100+ tool schemas):
+
+| Stack | Per-turn (warm, with MCP tool) |
+|-------|--------------------------------|
+| Anthropic Claude (cloud) | 3-15 s |
+| Ollama on H200 (70B) | 60-100 s |
+| Ollama on A100 80GB (70B) | 80-120 s |
+| Ollama on consumer 24GB (8B) | 10-20 s but tool discipline weak |
+
+The cloud-vs-local gap is structural (no server-side prompt cache, no batching, no proprietary kernels). For interactive triage, Anthropic mode is the right default. For scheduled investigations or compliance-driven air-gap, Ollama works.
+
+## Operator workflow examples
+
+**Switching to Ollama:**
+
+```bash
+cat >> /opt/talon/.env <<'EOF'
+TALON_PROVIDER=ollama
+TALON_OLLAMA_BASE_URL=http://host.docker.internal:11434
+TALON_OLLAMA_MODEL=llama3.3:70b
+EOF
+
+# Restart (macOS)
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+
+# Restart (Linux)
+systemctl --user restart nanoclaw
+```
+
+**Switching back to Anthropic:**
+
+```bash
+# Remove the Ollama lines from .env, then restart.
+# The container-runner will strip the leftover `model` field from
+# .claude/settings.json on next spawn — no manual cleanup needed.
+```
+
+## Failure modes & defenses
+
+- **Ollama endpoint unreachable**: Container hangs and gets reaped by Talon's idle timeout. No fallback to Anthropic — fail-closed.
+- **`api.anthropic.com` reachable from container**: Routed to 127.0.0.1 — DNS fails, request errors. Defense in depth.
+- **Model emits hallucinated tool results**: Inspect the per-session JSONL at `data/sessions/<group>/.claude/projects/-workspace-group/<sessionId>.jsonl` — look for `tool_use` blocks vs plain text content. If only text, the model isn't calling tools (use a larger model).
+
+## Verification smoke
+
+```bash
+# Unit: provider arg derivation (5 cases)
+node scripts/smoke-provider-args.mjs
+
+# Unit: .env loading + merge precedence (8 cases)
+node scripts/smoke-env-provider.mjs
+
+# Live: send a message via HTTP channel and watch container logs
+curl -sS -X POST http://localhost:3100/message \
+  -H 'x-api-key: <your HTTP_API_KEY>' -H 'content-type: application/json' \
+  -d '{"message":"Reply with: PROVIDER-OK","sender":"smoketest"}'
+```

--- a/docs/provider-examples/container.json.anthropic.example
+++ b/docs/provider-examples/container.json.anthropic.example
@@ -1,0 +1,6 @@
+{
+  "_comment": "Default Anthropic mode (Claude API via OneCLI gateway). This is what runs out of the box — no env overrides, OneCLI handles credential injection. Copy to container.json (or omit the file entirely; Talon defaults to Anthropic).",
+
+  "timeout": 600000,
+  "provider": "anthropic"
+}

--- a/docs/provider-examples/container.json.ollama.example
+++ b/docs/provider-examples/container.json.ollama.example
@@ -1,0 +1,15 @@
+{
+  "_comment": "PER-GROUP OVERRIDE — only needed when this customer should run a different provider than the instance-wide default in /opt/talon/.env. For single-tenant Talon (the common case), set TALON_PROVIDER + TALON_OLLAMA_* in .env instead and leave container.json absent. This file demonstrates an explicit per-customer override.",
+
+  "timeout": 600000,
+  "provider": "ollama",
+  "ollama": {
+    "baseUrl": "https://qggwu1g2nyt6dw-11434.proxy.runpod.net",
+    "model": "llama3.2:latest",
+    "apiKey": "ollama"
+  },
+  "blockedHosts": [
+    "api.openai.com",
+    "generativelanguage.googleapis.com"
+  ]
+}

--- a/scripts/smoke-env-provider.mjs
+++ b/scripts/smoke-env-provider.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// Smoke test for loadProviderEnvDefaults() + mergeProviderConfig().
+// Writes a temp .env, imports the compiled module, asserts behaviour.
+// Run: node scripts/smoke-env-provider.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const ROOT = process.cwd();
+const REAL_ENV = path.join(ROOT, '.env');
+const BACKUP = path.join(os.tmpdir(), `talon-smoke-env-${process.pid}.bak`);
+
+// Preserve real .env if present
+const hadRealEnv = fs.existsSync(REAL_ENV);
+if (hadRealEnv) fs.copyFileSync(REAL_ENV, BACKUP);
+
+let pass = 0, fail = 0;
+
+async function run(name, envContent, assertFn) {
+  fs.writeFileSync(REAL_ENV, envContent);
+  // bust ESM cache so loadProviderEnvDefaults re-reads .env
+  const mod = await import(`../dist/env.js?cb=${Date.now()}`);
+  try {
+    assertFn(mod);
+    console.log(`PASS  ${name}`);
+    pass++;
+  } catch (err) {
+    console.log(`FAIL  ${name}`);
+    console.log(`  ${err.message}`);
+    fail++;
+  }
+}
+
+function eq(a, b, msg) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(`${msg}\n  expected: ${JSON.stringify(b)}\n  got:      ${JSON.stringify(a)}`);
+  }
+}
+
+try {
+  await run('empty .env → no provider', '', ({ loadProviderEnvDefaults }) => {
+    eq(loadProviderEnvDefaults(), {}, 'expected empty config');
+  });
+
+  await run('TALON_PROVIDER=anthropic → provider only', 'TALON_PROVIDER=anthropic\n', ({ loadProviderEnvDefaults }) => {
+    eq(loadProviderEnvDefaults(), { provider: 'anthropic' }, 'expected anthropic provider');
+  });
+
+  await run(
+    'TALON_PROVIDER=ollama with all fields',
+    'TALON_PROVIDER=ollama\nTALON_OLLAMA_BASE_URL=https://x.runpod.net\nTALON_OLLAMA_MODEL=llama3.2:latest\nTALON_OLLAMA_API_KEY=sk-test\n',
+    ({ loadProviderEnvDefaults }) => {
+      eq(
+        loadProviderEnvDefaults(),
+        {
+          provider: 'ollama',
+          ollama: { baseUrl: 'https://x.runpod.net', model: 'llama3.2:latest', apiKey: 'sk-test' },
+        },
+        'expected full ollama config',
+      );
+    },
+  );
+
+  await run(
+    'TALON_PROVIDER=ollama missing url+model → falls back, no provider set',
+    'TALON_PROVIDER=ollama\n',
+    ({ loadProviderEnvDefaults }) => {
+      eq(loadProviderEnvDefaults(), {}, 'expected empty (warn + fallback)');
+    },
+  );
+
+  await run(
+    'TALON_BLOCKED_HOSTS comma-list parsed',
+    'TALON_BLOCKED_HOSTS=api.openai.com, generativelanguage.googleapis.com ,  bad.example\n',
+    ({ loadProviderEnvDefaults }) => {
+      eq(
+        loadProviderEnvDefaults(),
+        { blockedHosts: ['api.openai.com', 'generativelanguage.googleapis.com', 'bad.example'] },
+        'expected trimmed comma-split list',
+      );
+    },
+  );
+
+  await run('mergeProviderConfig: group wins on provider', '', ({ mergeProviderConfig }) => {
+    const merged = mergeProviderConfig(
+      { provider: 'ollama', ollama: { baseUrl: 'http://default', model: 'm1' } },
+      { provider: 'anthropic' },
+    );
+    eq(merged.provider, 'anthropic', 'expected group provider to win');
+  });
+
+  await run('mergeProviderConfig: blockedHosts unioned', '', ({ mergeProviderConfig }) => {
+    const merged = mergeProviderConfig(
+      { blockedHosts: ['api.openai.com'] },
+      { blockedHosts: ['evil.com'] },
+    );
+    eq(
+      [...merged.blockedHosts].sort(),
+      ['api.openai.com', 'evil.com'].sort(),
+      'expected union',
+    );
+  });
+
+  await run('mergeProviderConfig: env shallow-merged, group wins per key', '', ({ mergeProviderConfig }) => {
+    const merged = mergeProviderConfig(
+      { env: { FOO: 'env-val', BAR: 'keep' } },
+      { env: { FOO: 'group-val' } },
+    );
+    eq(merged.env, { FOO: 'group-val', BAR: 'keep' }, 'expected key-level override');
+  });
+} finally {
+  // Restore .env
+  if (hadRealEnv) fs.copyFileSync(BACKUP, REAL_ENV);
+  else fs.rmSync(REAL_ENV, { force: true });
+  fs.rmSync(BACKUP, { force: true });
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/smoke-provider-args.mjs
+++ b/scripts/smoke-provider-args.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Smoke test for buildProviderArgs(): verifies the helper produces the
+// expected env + --add-host args for each provider mode without spawning
+// any container. Re-implements buildProviderArgs inline so this script can
+// run against the published types without importing the .ts source.
+
+const cases = [
+  {
+    name: 'default (provider undefined)',
+    config: undefined,
+    expectEnv: {},
+    expectHosts: [],
+  },
+  {
+    name: 'provider=anthropic explicit',
+    config: { provider: 'anthropic' },
+    expectEnv: {},
+    expectHosts: [],
+  },
+  {
+    name: 'provider=ollama with RunPod URL',
+    config: {
+      provider: 'ollama',
+      ollama: {
+        baseUrl: 'https://qggwu1g2nyt6dw-11434.proxy.runpod.net',
+        model: 'llama3.2:latest',
+      },
+    },
+    expectEnv: {
+      ANTHROPIC_BASE_URL: 'https://qggwu1g2nyt6dw-11434.proxy.runpod.net',
+      ANTHROPIC_AUTH_TOKEN: 'ollama',
+      NO_PROXY: 'qggwu1g2nyt6dw-11434.proxy.runpod.net',
+      no_proxy: 'qggwu1g2nyt6dw-11434.proxy.runpod.net',
+    },
+    expectHosts: ['api.anthropic.com'],
+  },
+  {
+    name: 'provider=ollama + custom blockedHosts overlay',
+    config: {
+      provider: 'ollama',
+      ollama: {
+        baseUrl: 'http://host.docker.internal:11434',
+        model: 'qwen2.5:32b',
+      },
+      blockedHosts: ['api.openai.com', 'generativelanguage.googleapis.com'],
+    },
+    expectEnv: {
+      ANTHROPIC_BASE_URL: 'http://host.docker.internal:11434',
+      ANTHROPIC_AUTH_TOKEN: 'ollama',
+      NO_PROXY: 'host.docker.internal',
+      no_proxy: 'host.docker.internal',
+    },
+    expectHosts: ['api.anthropic.com', 'api.openai.com', 'generativelanguage.googleapis.com'],
+  },
+  {
+    name: 'env overlay overrides provider auto-derived',
+    config: {
+      provider: 'ollama',
+      ollama: { baseUrl: 'http://x:11434', model: 'm', apiKey: 'foo' },
+      env: { ANTHROPIC_AUTH_TOKEN: 'override' },
+    },
+    expectEnv: {
+      ANTHROPIC_BASE_URL: 'http://x:11434',
+      ANTHROPIC_AUTH_TOKEN: 'override',
+      NO_PROXY: 'x',
+      no_proxy: 'x',
+    },
+    expectHosts: ['api.anthropic.com'],
+  },
+];
+
+// Inlined copy of buildProviderArgs() — keep in sync with src/container-runner.ts.
+function buildProviderArgs(containerConfig) {
+  const env = {};
+  const blockedHosts = new Set();
+
+  if (containerConfig?.provider === 'ollama' && containerConfig.ollama) {
+    const { baseUrl, apiKey } = containerConfig.ollama;
+    env.ANTHROPIC_BASE_URL = baseUrl;
+    env.ANTHROPIC_AUTH_TOKEN = apiKey ?? 'ollama';
+    let host = null;
+    try { host = new URL(baseUrl).hostname; } catch { /* skip */ }
+    if (host) {
+      env.NO_PROXY = host;
+      env.no_proxy = host;
+    }
+    blockedHosts.add('api.anthropic.com');
+  }
+
+  if (containerConfig?.env) Object.assign(env, containerConfig.env);
+  for (const h of containerConfig?.blockedHosts ?? []) blockedHosts.add(h);
+
+  const envArgs = [];
+  for (const [k, v] of Object.entries(env)) envArgs.push('-e', `${k}=${v}`);
+  const addHostArgs = [];
+  for (const h of blockedHosts) addHostArgs.push('--add-host', `${h}:127.0.0.1`);
+  return { envArgs, addHostArgs, env, blockedHosts: [...blockedHosts] };
+}
+
+let pass = 0, fail = 0;
+for (const c of cases) {
+  const got = buildProviderArgs(c.config);
+  const envOk = JSON.stringify(got.env) === JSON.stringify(c.expectEnv);
+  const hostsOk = JSON.stringify(got.blockedHosts.sort()) === JSON.stringify([...c.expectHosts].sort());
+  if (envOk && hostsOk) {
+    console.log(`PASS  ${c.name}`);
+    pass++;
+  } else {
+    console.log(`FAIL  ${c.name}`);
+    if (!envOk) console.log(`  env expected: ${JSON.stringify(c.expectEnv)}\n  env got:      ${JSON.stringify(got.env)}`);
+    if (!hostsOk) console.log(`  hosts expected: ${JSON.stringify(c.expectHosts)}\n  hosts got:      ${JSON.stringify(got.blockedHosts)}`);
+    fail++;
+  }
+}
+
+console.log(`\n${pass} pass, ${fail} fail`);
+process.exit(fail === 0 ? 0 : 1);

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -17,7 +17,11 @@ import {
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
-import { loadProviderEnvDefaults, mergeProviderConfig, readEnvFile } from './env.js';
+import {
+  loadProviderEnvDefaults,
+  mergeProviderConfig,
+  readEnvFile,
+} from './env.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
 import {
@@ -188,12 +192,18 @@ function buildVolumeMounts(
   //     the SDK falls back to Anthropic defaults instead of erroring with
   //     "model qwen2.5-... doesn't exist" after a provider switch.
   // Read-merge-write to preserve other keys (env, hooks, permissions).
-  const effectiveConfig = mergeProviderConfig(PROVIDER_ENV_DEFAULTS, group.containerConfig);
+  const effectiveConfig = mergeProviderConfig(
+    PROVIDER_ENV_DEFAULTS,
+    group.containerConfig,
+  );
   try {
     const raw = fs.readFileSync(settingsFile, 'utf-8');
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     let dirty = false;
-    if (effectiveConfig.provider === 'ollama' && effectiveConfig.ollama?.model) {
+    if (
+      effectiveConfig.provider === 'ollama' &&
+      effectiveConfig.ollama?.model
+    ) {
       if (parsed.model !== effectiveConfig.ollama.model) {
         parsed.model = effectiveConfig.ollama.model;
         dirty = true;
@@ -392,9 +402,10 @@ function buildVolumeMounts(
  * function — no I/O. The caller appends to `args` in the right place
  * (after OneCLI applies its proxy vars so NO_PROXY actually wins).
  */
-function buildProviderArgs(
-  containerConfig: ContainerConfig | undefined,
-): { envArgs: string[]; addHostArgs: string[] } {
+function buildProviderArgs(containerConfig: ContainerConfig | undefined): {
+  envArgs: string[];
+  addHostArgs: string[];
+} {
   const env: Record<string, string> = {};
   const blockedHosts = new Set<string>();
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -17,7 +17,7 @@ import {
   ONECLI_URL,
   TIMEZONE,
 } from './config.js';
-import { readEnvFile } from './env.js';
+import { loadProviderEnvDefaults, mergeProviderConfig, readEnvFile } from './env.js';
 import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
 import { logger } from './logger.js';
 import {
@@ -29,13 +29,28 @@ import {
 } from './container-runtime.js';
 import { OneCLI } from '@onecli-sh/sdk';
 import { validateAdditionalMounts } from './mount-security.js';
-import { RegisteredGroup } from './types.js';
+import { ContainerConfig, RegisteredGroup } from './types.js';
 
 const onecli = new OneCLI({ url: ONECLI_URL });
 
 // Sentinel markers for robust output parsing (must match agent-runner)
 const OUTPUT_START_MARKER = '---NANOCLAW_OUTPUT_START---';
 const OUTPUT_END_MARKER = '---NANOCLAW_OUTPUT_END---';
+
+// Provider defaults from .env (single-tenant Talon — most operators set
+// TALON_PROVIDER once and every group inherits it). Loaded at module init;
+// per-group containerConfig still overrides via mergeProviderConfig().
+// Restart Talon to pick up .env changes.
+const PROVIDER_ENV_DEFAULTS = loadProviderEnvDefaults();
+if (PROVIDER_ENV_DEFAULTS.provider) {
+  logger.info(
+    {
+      provider: PROVIDER_ENV_DEFAULTS.provider,
+      ollamaModel: PROVIDER_ENV_DEFAULTS.ollama?.model,
+    },
+    'Provider defaults loaded from .env',
+  );
+}
 
 export interface ContainerInput {
   prompt: string;
@@ -164,6 +179,40 @@ function buildVolumeMounts(
         null,
         2,
       ) + '\n',
+    );
+  }
+
+  // Sync settings.json `model` field with the effective provider:
+  //   - provider=ollama → upsert model = ollama.model
+  //   - provider=anthropic (or unset) → remove any leftover model field so
+  //     the SDK falls back to Anthropic defaults instead of erroring with
+  //     "model qwen2.5-... doesn't exist" after a provider switch.
+  // Read-merge-write to preserve other keys (env, hooks, permissions).
+  const effectiveConfig = mergeProviderConfig(PROVIDER_ENV_DEFAULTS, group.containerConfig);
+  try {
+    const raw = fs.readFileSync(settingsFile, 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    let dirty = false;
+    if (effectiveConfig.provider === 'ollama' && effectiveConfig.ollama?.model) {
+      if (parsed.model !== effectiveConfig.ollama.model) {
+        parsed.model = effectiveConfig.ollama.model;
+        dirty = true;
+      }
+    } else if (parsed.model !== undefined) {
+      // Provider is anthropic (or unset) — strip any stale Ollama model
+      // left behind from a previous spawn. Without this, switching back
+      // to Anthropic fails with "model not found" until the file is
+      // hand-edited.
+      delete parsed.model;
+      dirty = true;
+    }
+    if (dirty) {
+      fs.writeFileSync(settingsFile, JSON.stringify(parsed, null, 2) + '\n');
+    }
+  } catch (err) {
+    logger.warn(
+      { group: group.name, settingsFile, err },
+      'Failed to sync model field in settings.json',
     );
   }
 
@@ -335,10 +384,66 @@ function buildVolumeMounts(
   return mounts;
 }
 
+/**
+ * Resolve provider-derived env + host-block args.
+ *
+ * Returns the env and `--add-host` args that the provider config implies,
+ * plus any raw `env`/`blockedHosts` overlays from `containerConfig`. Pure
+ * function — no I/O. The caller appends to `args` in the right place
+ * (after OneCLI applies its proxy vars so NO_PROXY actually wins).
+ */
+function buildProviderArgs(
+  containerConfig: ContainerConfig | undefined,
+): { envArgs: string[]; addHostArgs: string[] } {
+  const env: Record<string, string> = {};
+  const blockedHosts = new Set<string>();
+
+  if (containerConfig?.provider === 'ollama' && containerConfig.ollama) {
+    const { baseUrl, apiKey } = containerConfig.ollama;
+    env.ANTHROPIC_BASE_URL = baseUrl;
+    env.ANTHROPIC_AUTH_TOKEN = apiKey ?? 'ollama';
+    // NO_PROXY beats HTTPS_PROXY at request time — the SDK's HTTP client
+    // honours both lowercase and uppercase, so set both for safety.
+    let host: string | null = null;
+    try {
+      host = new URL(baseUrl).hostname;
+    } catch {
+      /* non-URL; skip NO_PROXY wiring */
+    }
+    if (host) {
+      env.NO_PROXY = host;
+      env.no_proxy = host;
+    }
+    // Fail-closed: if the SDK ever ignores ANTHROPIC_BASE_URL (e.g. someone
+    // unsets it post-spawn), DNS for api.anthropic.com resolves to the
+    // container itself — request fails fast instead of leaking traffic.
+    blockedHosts.add('api.anthropic.com');
+  }
+
+  // Raw overlay — user-provided env wins.
+  if (containerConfig?.env) {
+    Object.assign(env, containerConfig.env);
+  }
+  for (const h of containerConfig?.blockedHosts ?? []) {
+    blockedHosts.add(h);
+  }
+
+  const envArgs: string[] = [];
+  for (const [k, v] of Object.entries(env)) {
+    envArgs.push('-e', `${k}=${v}`);
+  }
+  const addHostArgs: string[] = [];
+  for (const h of blockedHosts) {
+    addHostArgs.push('--add-host', `${h}:127.0.0.1`);
+  }
+  return { envArgs, addHostArgs };
+}
+
 async function buildContainerArgs(
   mounts: VolumeMount[],
   containerName: string,
   isMain: boolean,
+  containerConfig: ContainerConfig | undefined,
   agentIdentifier?: string,
 ): Promise<string[]> {
   const args: string[] = ['run', '-i', '--rm', '--name', containerName];
@@ -353,31 +458,47 @@ async function buildContainerArgs(
 
   // OneCLI gateway handles credential injection — containers never see real secrets.
   // The gateway intercepts HTTPS traffic and injects API keys or OAuth tokens.
-  const onecliApplied = await onecli.applyContainerConfig(args, {
-    addHostMapping: false, // Nanoclaw already handles host gateway
-    agent: agentIdentifier,
-  });
-  if (onecliApplied) {
-    logger.info({ containerName }, 'OneCLI gateway config applied');
-  } else {
-    const { CLAUDE_CODE_OAUTH_TOKEN } = readEnvFile([
-      'CLAUDE_CODE_OAUTH_TOKEN',
-    ]);
-    if (CLAUDE_CODE_OAUTH_TOKEN) {
-      // Long-lived OAuth token (generated via `claude setup-token`) — inject
-      // directly so containers authenticate without a separate login.
-      args.push('-e', `CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}`);
-      logger.info(
-        { containerName },
-        'Injecting CLAUDE_CODE_OAUTH_TOKEN into container',
-      );
+  // Skip OneCLI entirely when running an Ollama-only container — there are no
+  // upstream secrets to inject and we don't want the proxy intercepting our
+  // ANTHROPIC_BASE_URL redirect.
+  if (containerConfig?.provider !== 'ollama') {
+    const onecliApplied = await onecli.applyContainerConfig(args, {
+      addHostMapping: false, // Nanoclaw already handles host gateway
+      agent: agentIdentifier,
+    });
+    if (onecliApplied) {
+      logger.info({ containerName }, 'OneCLI gateway config applied');
     } else {
-      logger.warn(
-        { containerName },
-        'No credentials available — container may fail to authenticate',
-      );
+      const { CLAUDE_CODE_OAUTH_TOKEN } = readEnvFile([
+        'CLAUDE_CODE_OAUTH_TOKEN',
+      ]);
+      if (CLAUDE_CODE_OAUTH_TOKEN) {
+        // Long-lived OAuth token (generated via `claude setup-token`) — inject
+        // directly so containers authenticate without a separate login.
+        args.push('-e', `CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}`);
+        logger.info(
+          { containerName },
+          'Injecting CLAUDE_CODE_OAUTH_TOKEN into container',
+        );
+      } else {
+        logger.warn(
+          { containerName },
+          'No credentials available — container may fail to authenticate',
+        );
+      }
     }
+  } else {
+    logger.info(
+      { containerName, provider: 'ollama' },
+      'Provider=ollama — skipping OneCLI gateway, using ANTHROPIC_BASE_URL redirect',
+    );
   }
+
+  // Provider-derived env + host blocks. Pushed AFTER OneCLI so NO_PROXY
+  // (set by Ollama provider) overrides any HTTPS_PROXY OneCLI may have applied.
+  const { envArgs, addHostArgs } = buildProviderArgs(containerConfig);
+  args.push(...envArgs);
+  args.push(...addHostArgs);
 
   // Runtime-specific args for host gateway resolution
   args.push(...hostGatewayArgs());
@@ -441,10 +562,17 @@ export async function runContainerAgent(
   const agentIdentifier = input.isMain
     ? undefined
     : group.folder.toLowerCase().replace(/_/g, '-');
+  // Merge .env provider defaults with per-group overrides — single source
+  // of truth for provider-related decisions in buildContainerArgs.
+  const effectiveContainerConfig = mergeProviderConfig(
+    PROVIDER_ENV_DEFAULTS,
+    group.containerConfig,
+  );
   const containerArgs = await buildContainerArgs(
     mounts,
     containerName,
     input.isMain,
+    effectiveContainerConfig,
     agentIdentifier,
   );
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -76,7 +76,10 @@ export function loadProviderEnvDefaults(): Partial<ContainerConfig> {
   if (provider === 'anthropic' || provider === 'ollama') {
     out.provider = provider;
   } else if (provider) {
-    logger.warn({ provider }, 'TALON_PROVIDER must be "anthropic" or "ollama" — ignoring');
+    logger.warn(
+      { provider },
+      'TALON_PROVIDER must be "anthropic" or "ollama" — ignoring',
+    );
   }
 
   if (out.provider === 'ollama') {
@@ -89,13 +92,17 @@ export function loadProviderEnvDefaults(): Partial<ContainerConfig> {
       out.ollama = {
         baseUrl: env.TALON_OLLAMA_BASE_URL,
         model: env.TALON_OLLAMA_MODEL,
-        ...(env.TALON_OLLAMA_API_KEY ? { apiKey: env.TALON_OLLAMA_API_KEY } : {}),
+        ...(env.TALON_OLLAMA_API_KEY
+          ? { apiKey: env.TALON_OLLAMA_API_KEY }
+          : {}),
       };
     }
   }
 
   if (env.TALON_BLOCKED_HOSTS) {
-    out.blockedHosts = env.TALON_BLOCKED_HOSTS.split(',').map((s) => s.trim()).filter(Boolean);
+    out.blockedHosts = env.TALON_BLOCKED_HOSTS.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
   }
 
   return out;
@@ -127,7 +134,10 @@ export function mergeProviderConfig(
   // Union blockedHosts so group can add to (not replace) the .env list.
   if (envDefaults.blockedHosts || groupConfig?.blockedHosts) {
     merged.blockedHosts = [
-      ...new Set([...(envDefaults.blockedHosts ?? []), ...(groupConfig?.blockedHosts ?? [])]),
+      ...new Set([
+        ...(envDefaults.blockedHosts ?? []),
+        ...(groupConfig?.blockedHosts ?? []),
+      ]),
     ];
   }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { logger } from './logger.js';
+import type { ContainerConfig } from './types.js';
 
 /**
  * Parse the .env file and return values for the requested keys.
@@ -40,4 +41,95 @@ export function readEnvFile(keys: string[]): Record<string, string> {
   }
 
   return result;
+}
+
+/**
+ * Read provider config defaults from `.env`.
+ *
+ * Most Talon installs are single-tenant (one customer = one Talon instance),
+ * so the operator just sets a few env vars and every group inherits the
+ * same provider. Per-group `containerConfig` (DB-backed) still wins via
+ * `mergeProviderConfig()` for the rare multi-tenant case.
+ *
+ * Recognised keys:
+ *   TALON_PROVIDER          'anthropic' | 'ollama'
+ *   TALON_OLLAMA_BASE_URL   e.g. https://x-11434.proxy.runpod.net
+ *   TALON_OLLAMA_MODEL      e.g. llama3.2:latest
+ *   TALON_OLLAMA_API_KEY    optional, defaults to "ollama"
+ *   TALON_BLOCKED_HOSTS     comma-separated, e.g. "api.openai.com,generativelanguage.googleapis.com"
+ *
+ * Returns an empty `{}` when no provider keys are present — callers should
+ * treat that as "no override, use defaults".
+ */
+export function loadProviderEnvDefaults(): Partial<ContainerConfig> {
+  const env = readEnvFile([
+    'TALON_PROVIDER',
+    'TALON_OLLAMA_BASE_URL',
+    'TALON_OLLAMA_MODEL',
+    'TALON_OLLAMA_API_KEY',
+    'TALON_BLOCKED_HOSTS',
+  ]);
+
+  const out: Partial<ContainerConfig> = {};
+
+  const provider = env.TALON_PROVIDER?.toLowerCase();
+  if (provider === 'anthropic' || provider === 'ollama') {
+    out.provider = provider;
+  } else if (provider) {
+    logger.warn({ provider }, 'TALON_PROVIDER must be "anthropic" or "ollama" — ignoring');
+  }
+
+  if (out.provider === 'ollama') {
+    if (!env.TALON_OLLAMA_BASE_URL || !env.TALON_OLLAMA_MODEL) {
+      logger.warn(
+        'TALON_PROVIDER=ollama requires TALON_OLLAMA_BASE_URL and TALON_OLLAMA_MODEL — falling back to anthropic',
+      );
+      delete out.provider;
+    } else {
+      out.ollama = {
+        baseUrl: env.TALON_OLLAMA_BASE_URL,
+        model: env.TALON_OLLAMA_MODEL,
+        ...(env.TALON_OLLAMA_API_KEY ? { apiKey: env.TALON_OLLAMA_API_KEY } : {}),
+      };
+    }
+  }
+
+  if (env.TALON_BLOCKED_HOSTS) {
+    out.blockedHosts = env.TALON_BLOCKED_HOSTS.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+
+  return out;
+}
+
+/**
+ * Merge `.env` provider defaults with per-group container config.
+ *
+ * Precedence: defaults → .env → group config (group wins).
+ *
+ * - `provider`/`ollama`: per-group entry, if present, replaces the .env value
+ *   wholesale (mixing fields would be confusing).
+ * - `env`/`blockedHosts`: shallow-merged so a group can extend the base.
+ * - `additionalMounts`/`timeout`: untouched — these are group-only by design.
+ */
+export function mergeProviderConfig(
+  envDefaults: Partial<ContainerConfig>,
+  groupConfig: ContainerConfig | undefined,
+): ContainerConfig {
+  const merged: ContainerConfig = { ...envDefaults, ...groupConfig };
+
+  // Group's `provider`/`ollama` already won via spread above; nothing to do.
+
+  // Shallow-merge env-var overlay so group can add keys without clobbering .env.
+  if (envDefaults.env || groupConfig?.env) {
+    merged.env = { ...envDefaults.env, ...groupConfig?.env };
+  }
+
+  // Union blockedHosts so group can add to (not replace) the .env list.
+  if (envDefaults.blockedHosts || groupConfig?.blockedHosts) {
+    merged.blockedHosts = [
+      ...new Set([...(envDefaults.blockedHosts ?? []), ...(groupConfig?.blockedHosts ?? [])]),
+    ];
+  }
+
+  return merged;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,9 +27,54 @@ export interface AllowedRoot {
   description?: string;
 }
 
+/**
+ * Provider selection for the agent runtime inside the container.
+ *
+ * - `anthropic` (default): Claude API via OneCLI gateway. No special wiring.
+ * - `ollama`: Redirect the Claude SDK at a local/remote Ollama instance via
+ *   `ANTHROPIC_BASE_URL` env override. Ollama 0.4+ speaks the Anthropic
+ *   v1/messages API natively, so the SDK can't tell the difference and
+ *   no provider-side code change is needed.
+ *
+ *   When `provider === 'ollama'`, the container-runner:
+ *     1. Injects `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` env vars.
+ *     2. Adds `NO_PROXY` for the Ollama host so the OneCLI HTTPS_PROXY
+ *        doesn't intercept the redirect (NO_PROXY beats HTTPS_PROXY at
+ *        request time).
+ *     3. Upserts `model` into the per-group `.claude/settings.json` so
+ *        the SDK picks up the local model name.
+ *     4. Routes `api.anthropic.com` to 127.0.0.1 via `--add-host` so any
+ *        accidental escape attempt fails closed instead of leaking traffic.
+ */
+export type AgentProvider = 'anthropic' | 'ollama';
+
+export interface OllamaProviderConfig {
+  /** Base URL for the Ollama HTTP server. e.g. "http://host.docker.internal:11434" */
+  baseUrl: string;
+  /** Ollama model tag. e.g. "qwen2.5:32b-instruct-q4_K_M" */
+  model: string;
+  /** API key string. Ollama ignores the value but the SDK requires one set. Default: "ollama". */
+  apiKey?: string;
+}
+
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
+  /** Agent provider. Default: 'anthropic'. Set 'ollama' for fully-local/air-gapped runs. */
+  provider?: AgentProvider;
+  /** Required when provider === 'ollama'. */
+  ollama?: OllamaProviderConfig;
+  /**
+   * Raw env-var overlay. Merged after provider auto-derived vars,
+   * so this can override anything (escape hatch).
+   */
+  env?: Record<string, string>;
+  /**
+   * Hostnames to route to 127.0.0.1 inside the container via `--add-host`.
+   * Used to fail-closed on escape attempts (e.g. block `api.anthropic.com`
+   * when running an Ollama-only container).
+   */
+  blockedHosts?: string[];
 }
 
 export interface RegisteredGroup {


### PR DESCRIPTION
## Summary

Talon can now run fully air-gapped on a customer's local Ollama by setting four lines in `.env`. The Claude Agent SDK is redirected at the local endpoint via `ANTHROPIC_BASE_URL` — Ollama 0.4+ speaks the Anthropic v1/messages API natively, so no provider-side code change is needed beyond env wiring.

This PR contains **three commits**:

1. **`c2af0c6` spike(providers): port v2 provider abstraction in isolation** — earlier exploratory port of upstream nanoclaw-v2's container-side provider barrel. Kept as a reference artifact for future flexibility (true multi-protocol providers like OpenCode), not yet wired.
2. **`d890f3d` feat(providers): add Ollama as a swappable agent provider** — the actual feature.
3. **`5c82f93` chore(format): prettier on new provider files** — pre-commit hook formatting follow-up.

## Operator UX

```bash
# /opt/talon/.env

# Default — Anthropic via OneCLI (no action required)

# Air-gapped mode
TALON_PROVIDER=ollama
TALON_OLLAMA_BASE_URL=http://host.docker.internal:11434
TALON_OLLAMA_MODEL=llama3.3:70b
TALON_OLLAMA_API_KEY=ollama
```

Restart Talon. Every group inherits the provider. Per-group `container.json` still wins for the rare multi-tenant case.

## What the container-runner does in Ollama mode

1. Skips OneCLI gateway (no upstream secrets to inject)
2. Injects `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` env vars
3. Sets `NO_PROXY` for the Ollama host so any HTTPS_PROXY doesn't intercept
4. Upserts `model` into `.claude/settings.json` (and strips it on switch back to Anthropic so the SDK falls back to defaults instead of erroring)
5. Routes `api.anthropic.com` to `127.0.0.1` via `--add-host` to fail-closed on accidental escape attempts

## Schema additions

```typescript
ContainerConfig.provider:     'anthropic' | 'ollama'
ContainerConfig.ollama:       { baseUrl, model, apiKey? }
ContainerConfig.env:          Record<string, string>     // raw overlay
ContainerConfig.blockedHosts: string[]                   // route to loopback
```

## Live verification on RunPod H200

End-to-end tests with both `qwen2.5:32b-instruct` (128K) and `llama3.3:70b`:

| Test | Result |
|------|--------|
| Baseline ping | Pass — model returns exact reply |
| Mempalace MCP search (real tool_use block) | Pass — 1804 chars of real MCP data, accurate summary |
| Multi-MCP turn (mempalace + customer lookup) | Pass — multi-round tool calling works |
| Switch back to Anthropic | Pass — settings.json model field stripped automatically |
| Fail-closed (Ollama unreachable) | Pass — container hangs and reaps, no fallback to Anthropic |

Smaller models (`llama3.2:3b`, `qwen2.5-coder:7b`, `qwen2.5:7b-instruct`) confirmed to **hallucinate tool results** under the full Claude Code preset + 100+ tool schemas. 32B is the practical floor for tool-calling discipline; 70B is the recommended production model.

## Latency caveat (documented)

- **Anthropic Claude:** 3-15 s/turn
- **Ollama on H200 + 70B:** 60-100 s/turn

The gap is structural — no server-side prompt cache, no continuous batching, no proprietary kernels. Acceptable for scheduled investigations and compliance demos. Interactive triage probably stays on Anthropic. vLLM/TensorRT-LLM follow-up could narrow the gap to ~25-40 s/turn.

## Test plan

- [x] `npm run build` — clean
- [x] `node scripts/smoke-provider-args.mjs` — 5/5 cases pass (env injection + host blocks per provider mode + escape-hatch overlay precedence)
- [x] `node scripts/smoke-env-provider.mjs` — 8/8 cases pass (.env parsing, provider/blockedHosts merging, group-overrides-defaults precedence)
- [x] Live test: Anthropic mode ping
- [x] Live test: Ollama mode ping (qwen2.5:32b + llama3.3:70b)
- [x] Live test: real MCP tool roundtrip via Ollama (verified tool_use blocks in session jsonl)
- [x] Live test: switch from Ollama back to Anthropic — model field stripped automatically
- [x] Live test: dead Ollama endpoint — container fails closed, no leak to api.anthropic.com

## Follow-ups (not in this PR)

- vLLM deployment option for customers who want lower per-turn latency on the same hardware (~25-40s/turn vs ~100s/turn). Same `ANTHROPIC_BASE_URL` redirect we just built — just a different upstream image.
- Pre-warmed container pool to eliminate the ~10-20s spawn cost per turn.
- Streaming response back to channel — UX win, doesn't change total latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)