### PR TITLE
fix(http-channel): inline SubmitAiAnalystReportTool field list in /investigate prompt

### DIFF
--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -375,7 +375,21 @@ Steps:
 1. Skip Step 0 deduplication — this job has already been registered by the caller with id="${jobId}". Call UpdateAiAnalystJobTool(job_id="${jobId}", status="running") immediately.
 2. Pull the alert from MySQL using alert_id=${alert_id} and customer_code="${customer_code}".
 3. Follow Steps 2–6 from CLAUDE.md exactly (fetch raw event + index mapping, detect alert type, load template, extract IOCs, threat intel, SIEM correlation).
-${stepOverrideInstruction}4. Write back to CoPilot using job_id="${jobId}" and the report/IOC tools.
+${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in order. The four body fields on SubmitAiAnalystReportTool (severity_assessment, summary, report_markdown, recommended_actions) carry the entire human-readable investigation output; a call missing any of them persists a blank row that surfaces as an empty report in CoPilot. Pass all of them every time, even on trivial false positives.
+
+   a. mcp__copilot__UpdateAiAnalystJobTool(job_id="${jobId}", status="completed", template_used=<template key or null>)
+
+   b. mcp__copilot__SubmitAiAnalystReportTool — returns report_id:
+        job_id="${jobId}"
+        alert_id=${alert_id}
+        customer_code="${customer_code}"
+        severity_assessment=<Critical|High|Medium|Low|Informational>
+        summary=<1-2 sentence tl;dr>
+        report_markdown=<full structured markdown report>
+        recommended_actions=<action list>
+
+   c. mcp__copilot__SubmitAiAnalystIocsTool(report_id=<from 4b>, alert_id=${alert_id}, customer_code="${customer_code}", iocs=[...])
+
 5. Write the eval JSON to /workspace/group/evals/${alert_id}-${jobId}.json as instructed in CLAUDE.md Step 6.
 6. Send the full investigation report via send_message.`;
 


### PR DESCRIPTION
## Summary

The webhook `/investigate` prompt instructs the agent to "Write back to CoPilot using job_id and the report/IOC tools", relying on `CLAUDE.md` for the actual `SubmitAiAnalystReportTool` schema. When the agent's long-running Claude Code session compacts, the field list can fall out of context — subsequent calls land with only `{ job_id, alert_id, customer_code }` and the row persists with `NULL` body fields, surfacing as an empty report in CoPilot.

This PR re-injects the explicit field list inside the per-investigation prompt so the schema arrives with every webhook, regardless of session-summary drift.

## Symptom we hit in production

After ~9 days of session continuity (56 compactions, 59MB jsonl), a compaction at 04:14 UTC truncated the report-schema details. Every webhook investigation after that — 10 in a row — produced rows like:

```
alert_id | report_id | severity | report_markdown
1261     | 495       | NULL     | NULL
1262     | 496       | NULL     | NULL
...
1270     | 504       | NULL     | NULL
```

while IOC submissions on the same investigation went through fine (they got the `report_id` back and posted normally). The agent was clearly still functioning — just calling one tool with the wrong arg shape.

Recovering required deleting the empty rows, archiving the session jsonl, clearing the `sessions.session_id` row in `messages.db`, restarting Talon, and re-firing `/investigate`. Hardening the prompt would have prevented all of it.

## What this changes

`src/channels/http.ts` — replace the one-line vague step 4 with an explicit three-tool sequence that names every required argument by position, plus a short rationale ("a call missing any of them persists a blank row…") so the model can't elide the body fields as "obvious" filler. Identical phrasing pattern to the existing scheduled-task prompt that already does this correctly.

No type changes, no logic changes, no other files touched.

## Test plan

- [ ] `npm run typecheck` (pure string change inside an existing template literal, but worth confirming)
- [ ] `npm test`
- [ ] Manually `POST /investigate` once on a fresh session and confirm the resulting `ai_analyst_report` row has populated `severity_assessment`, `summary`, `report_markdown`, `recommended_actions`
- [ ] Repeat after a forced session compaction to confirm the schema survives

## Related observations (not in this PR)

While debugging this I noticed a few other things worth a separate look:

- `talon.service` uses `KillMode=process`, so every restart leaves an orphan `nanoclaw-copilot-*` container that the next start has to clean up (visible as `Unit process N (docker) remains running after unit stopped` in the journal).
- No log rotation on `/opt/talon/logs/talon.{log,error.log}` — the production file is 376KB after ~9 days and only growing.
- Long-lived agent sessions are inherently fragile against schema-drift like this. A bounded session lifetime (rotate after N investigations or M MB) would reduce the surface area; happy to follow up with a separate PR.