### PR TITLE
feat(agent-runner): log prompt cache hit rate per turn

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -127,6 +127,39 @@ function log(message: string): void {
   console.error(`[agent-runner] ${message}`);
 }
 
+// Token usage reported on the SDK `result` message. The Claude Agent SDK
+// surfaces the same cache fields the Anthropic API returns, so this is how we
+// see whether prompt caching is actually working (it's managed by the SDK; we
+// can't set cache_control ourselves on this code path).
+interface CacheUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+// Log cache hit rate per turn. Hit rate = cached input / total input tokens.
+// If `read` stays at 0 across turns, a silent invalidator is busting the
+// prefix (e.g. dynamic content in the system prompt or a varying tool set).
+function logCacheUsage(
+  prefix: string,
+  usage: CacheUsage | undefined,
+  costUsd: number | undefined,
+): void {
+  if (!usage) return;
+  const fresh = usage.input_tokens ?? 0;
+  const write = usage.cache_creation_input_tokens ?? 0;
+  const read = usage.cache_read_input_tokens ?? 0;
+  const out = usage.output_tokens ?? 0;
+  const totalIn = fresh + write + read;
+  const hitRate = totalIn > 0 ? ((read / totalIn) * 100).toFixed(1) : '0.0';
+  const cost = typeof costUsd === 'number' ? ` cost=$${costUsd.toFixed(4)}` : '';
+  log(
+    `${prefix} cache: read=${read} write=${write} fresh=${fresh} out=${out} ` +
+      `hitRate=${hitRate}% (in=${totalIn})${cost}`,
+  );
+}
+
 // Truncate large strings for log readability while keeping enough signal to
 // debug a tool call. JSON.stringify handles MCP tool inputs/outputs that are
 // nested objects.
@@ -622,6 +655,11 @@ async function runQuery(
         'result' in message ? (message as { result?: string }).result : null;
       log(
         `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
+      );
+      logCacheUsage(
+        `Result #${resultCount}`,
+        (message as { usage?: CacheUsage }).usage,
+        (message as { total_cost_usd?: number }).total_cost_usd,
       );
       writeOutput({
         status: 'success',

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -11,6 +11,30 @@ function log(msg: string): void {
   console.error(`[claude-provider] ${msg}`);
 }
 
+// Token usage reported on the SDK `result` message. The Agent SDK surfaces the
+// same cache fields the Anthropic API returns — this is how we confirm prompt
+// caching (managed by the SDK) is actually landing hits.
+interface CacheUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+// Log cache hit rate per turn. Hit rate = cached input / total input tokens.
+// If `read` stays at 0 across turns, a silent invalidator is busting the prefix.
+function logCacheUsage(prefix: string, usage: CacheUsage | undefined, costUsd: number | undefined): void {
+  if (!usage) return;
+  const fresh = usage.input_tokens ?? 0;
+  const write = usage.cache_creation_input_tokens ?? 0;
+  const read = usage.cache_read_input_tokens ?? 0;
+  const out = usage.output_tokens ?? 0;
+  const totalIn = fresh + write + read;
+  const hitRate = totalIn > 0 ? ((read / totalIn) * 100).toFixed(1) : '0.0';
+  const cost = typeof costUsd === 'number' ? ` cost=$${costUsd.toFixed(4)}` : '';
+  log(`${prefix} cache: read=${read} write=${write} fresh=${fresh} out=${out} hitRate=${hitRate}% (in=${totalIn})${cost}`);
+}
+
 // Deferred SDK builtins that either sidestep nanoclaw's own scheduling or
 // don't fit our async message-passing model (they're designed for Claude
 // Code's interactive UI and would hang here).
@@ -304,6 +328,7 @@ export class ClaudeProvider implements AgentProvider {
           yield { type: 'init', continuation: message.session_id };
         } else if (message.type === 'result') {
           const text = 'result' in message ? (message as { result?: string }).result ?? null : null;
+          logCacheUsage('Result', (message as { usage?: CacheUsage }).usage, (message as { total_cost_usd?: number }).total_cost_usd);
           yield { type: 'result', text };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };


### PR DESCRIPTION
## Summary

Adds per-turn prompt cache usage logging to the agent runner so operators can confirm prompt caching is actually landing hits.

The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) manages prompt caching internally — Talon never constructs `messages.create()`, so we can't set `cache_control` ourselves. What we *can* do is surface the `usage.cache_*` fields the SDK reports on each `result` message, giving visibility into hit rates and catching silent prefix invalidators.

## Changes

- New `logCacheUsage` helper + `CacheUsage` type added to both model-invocation paths:
  - `container/agent-runner/src/index.ts` — the live query path
  - `container/agent-runner/src/providers/claude.ts` — the provider abstraction
- Called on every `result` message; logs read/write/fresh/out token counts, computed hit rate, and turn cost.

## Example output

```
[agent-runner] Result #1 cache: read=18432 write=2106 fresh=312 out=487 hitRate=89.7% (in=20850) cost=$0.0214
```

- `read` = tokens served from cache (~0.1× price) — the number you want high
- `write` = tokens written to cache this turn (~1.25×)
- `fresh` = uncached input at full price
- `hitRate` = `read / (read + write + fresh)`

If `read` stays at 0 across turns of the same conversation, a silent invalidator is busting the cached prefix.

## Verification

- Installed agent-runner deps and ran `npx tsc --noEmit` → exit 0
- Confirmed against the SDK types that `SDKResultMessage.usage` carries the snake_case `cache_read_input_tokens` / `cache_creation_input_tokens` / `input_tokens` / `output_tokens` fields, so the log populates rather than being silently empty

## Notes

- Logging takes effect after a container rebuild (`./container/build.sh`); prune the buildkit builder first if the `agent-runner` COPY is stale.
- No behavior change beyond logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)