### PR TITLE
fix(http-channel): inline asset-resolution SQL in /investigate prompt

### DIFF
--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -373,7 +373,16 @@ Alert to investigate:
 
 Steps:
 1. Skip Step 0 deduplication — this job has already been registered by the caller with id="${jobId}". Call UpdateAiAnalystJobTool(job_id="${jobId}", status="running") immediately.
-2. Pull the alert from MySQL using alert_id=${alert_id} and customer_code="${customer_code}".
+2. Resolve the alert source and target document via MySQL before any OpenSearch query. The alert_id passed here is CoPilot's internal DB counter and is NOT a field on raw SIEM documents — searching OpenSearch for it returns nothing, and falling back to a time-window query will pick up unrelated noise (typically the agent's own container-startup events) and produce a report about the wrong event. Run exactly this query via mcp__mysql__mysql_query:
+
+     SELECT a.id, a.alert_name, a.source, a.alert_creation_time,
+            a.customer_code, ast.asset_name, ast.agent_id,
+            ast.index_name, ast.index_id
+     FROM incident_management_alert a
+     LEFT JOIN incident_management_asset ast ON ast.alert_linked = a.id
+     WHERE a.id = ${alert_id} AND a.customer_code = "${customer_code}";
+
+   Treat the returned (index_name, index_id) as the authoritative pointer to the raw event for every subsequent SIEM lookup. The 'source' column ("wazuh", "office365", "misp", …) tells you which OpenSearch index family the event lives in. If the row is missing, ast.index_name is empty, or the source is unrecognised, mark the job 'failed' with a descriptive error_message rather than guessing from timestamps.
 3. Follow Steps 2–6 from CLAUDE.md exactly (fetch raw event + index mapping, detect alert type, load template, extract IOCs, threat intel, SIEM correlation).
 ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in order. The four body fields on SubmitAiAnalystReportTool (severity_assessment, summary, report_markdown, recommended_actions) carry the entire human-readable investigation output; a call missing any of them persists a blank row that surfaces as an empty report in CoPilot. Pass all of them every time, even on trivial false positives.
 


### PR DESCRIPTION
## What

Step 2 of the `/investigate` webhook prompt currently says only `"Pull the alert from MySQL using alert_id=X and customer_code=Y"`, deferring to CLAUDE.md for the actual join and the MCP tool to call. Replace it with the explicit join inline, name the tool, and state the failure mode if MySQL is unreachable or the asset linkage is missing.

## Why

When the agent's long-running session compacts, the connective tissue between Step 2 and CLAUDE.md Step 1 can be lost. The fallthrough path is harmful: the agent searches OpenSearch by `alert_id` (which is CoPilot's internal DB counter, not a field on raw SIEM documents) → finds nothing → falls back to a time-window query that picks up unrelated noise (typically the agent's own container-startup events) → produces a confident-looking report about the wrong event.

Concrete recent surface area: when this fires for an `office365`-source alert, the agent investigates a coincidentally-timed `wazuh-*` event instead. The report attached to the alert in CoPilot then describes a different event entirely.

This is the same shape of fix as #7 for the output side — replace vague Step N with the explicit tool call + the consequence of skipping it, so the instruction survives compaction.

## How it works

`src/channels/http.ts`, the `/investigate` prompt body:

```diff
-2. Pull the alert from MySQL using alert_id=${alert_id} and customer_code="${customer_code}".
+2. Resolve the alert source and target document via MySQL before any OpenSearch query.
+   The alert_id passed here is CoPilot's internal DB counter and is NOT a field on raw
+   SIEM documents — searching OpenSearch for it returns nothing, and falling back to a
+   time-window query will pick up unrelated noise (typically the agent's own
+   container-startup events) and produce a report about the wrong event. Run exactly
+   this query via mcp__mysql__mysql_query:
+
+     SELECT a.id, a.alert_name, a.source, a.alert_creation_time,
+            a.customer_code, ast.asset_name, ast.agent_id,
+            ast.index_name, ast.index_id
+     FROM incident_management_alert a
+     LEFT JOIN incident_management_asset ast ON ast.alert_linked = a.id
+     WHERE a.id = ${alert_id} AND a.customer_code = "${customer_code}";
+
+   Treat the returned (index_name, index_id) as the authoritative pointer to the raw
+   event for every subsequent SIEM lookup. The 'source' column ("wazuh", "office365",
+   "misp", …) tells you which OpenSearch index family the event lives in. If the row
+   is missing, ast.index_name is empty, or the source is unrecognised, mark the job
+   'failed' with a descriptive error_message rather than guessing from timestamps.
```

One file, +10/-1, no type changes, no logic changes.

## How it was tested

- `npm run build` — clean, dist regenerates as expected.
- Patched a production install with the same diff, then re-fired a cluster of six previously-misdiagnosed alerts:
  - 5 `source=wazuh` alerts where the misdiagnosis pattern had been "agent container startup FP", now correctly identify the real Windows hosts and PowerShell modules involved.
  - 1 `source=office365` alert where the misdiagnosis pattern had been a coincidentally-timed Sysmon DLL load, now correctly identifies the Microsoft Defender for Office 365 mail event.
- Agent's first action in each case is now `mcp__mysql__mysql_query` with the inlined SQL, followed by `opensearch_anon__get_document` against the `(index_name, index_id)` the query returned. No more time-window guessing fallback.

## Security impact

None — no PII handling, no mount-allowlist changes, no MCP server wrappers. Pure prompt content adjustment inside an existing template literal.

## Related observations (not in this PR)

- A persistent agent session running for many days accumulates compaction-driven drift; the empty-report and wrong-event patterns we've seen both stem from this. Bounded session lifetime (rotate after N investigations or M MB) would reduce the surface area of this class of bug — happy to follow up with a separate PR if there's interest.
- `talon.service` still uses `KillMode=process`, which leaves an orphan agent container on every restart. Separate fix.