### PR TITLE
fix(onecli): grant vault secrets via the current grants API

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,16 @@ After OneCLI is running, register your Claude OAuth token (or API key) in the Va
 bash scripts/migrate-anthropic-to-vault.sh
 ```
 
-This reads `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) from `.env` and registers it as an `anthropic` secret bound to `api.anthropic.com`. The raw token stays in `.env` for now so you can verify the Vault path works first.
+This reads `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) from `.env` and registers it as an `anthropic` secret bound to `api.anthropic.com`, then **grants that secret to every OneCLI agent**. The raw token stays in `.env` for now so you can verify the Vault path works first.
+
+Registering a secret is not enough on its own — an agent with no grant to it gets refused at injection time. Non-main groups authenticate as their own agent (`agentIdentifier` in `src/container-runner.ts`), so each group's agent needs the grant. Confirm with:
+
+```bash
+onecli agents list
+onecli agents grants list --id <agent id>   # expect "Anthropic" under secrets
+```
+
+The script exits `4` if the secret registered but any agent was left without access.
 
 Restart Talon and confirm with:
 

--- a/docs/DEBUG_CHECKLIST.md
+++ b/docs/DEBUG_CHECKLIST.md
@@ -151,6 +151,36 @@ ls -la store/auth/
 npm run auth
 ```
 
+## OneCLI 401: "credentials exist but this agent does not have access"
+
+The container reached the gateway, but the agent it authenticated as has no
+grant to the Anthropic secret. Registering a secret does not grant it.
+
+Main uses OneCLI's default agent; every other group authenticates as an agent
+named after its folder (`agentIdentifier` in `src/container-runner.ts`), so a
+group-specific 401 usually means only that one agent is missing the grant.
+
+```bash
+# Which agent does the failing group use? (lowercased folder, _ -> -)
+onecli agents list
+
+# What does that agent actually have?
+onecli agents grants list --id <agent id>    # expect the secret under "secrets"
+
+# Find the secret, then grant it
+onecli secrets list
+onecli agents grants attach-secret --id <agent id> --secret-id <secret id>
+```
+
+Takes effect immediately — grants are checked per request, no restart needed.
+
+Re-running `scripts/migrate-anthropic-to-vault.sh` grants the secret to every
+agent and is safe to repeat; it exits `4` if any agent was left without access.
+
+Note that `onecli agents secrets` / `set-secrets` are the removed pre-grants
+API. They are still listed in `onecli agents --help` but the gateway answers
+`{"code": "GONE"}`, so help output is not a reliable capability check.
+
 ## Service Management
 
 ```bash

--- a/scripts/lib/onecli-grants.sh
+++ b/scripts/lib/onecli-grants.sh
@@ -1,0 +1,157 @@
+# shellcheck shell=bash
+#
+# Shared helper: attach a Vault secret to every OneCLI agent.
+#
+# Source this after defining log()/warn() (fallbacks are provided below).
+# Requires: onecli, curl, python3.
+#
+# OneCLI has two generations of this API:
+#
+#   grants (current)  onecli agents grants list|attach-secret
+#   legacy  (<=1.18)  onecli agents secrets|set-secrets
+#
+# The legacy endpoints were removed server-side and now answer with
+# {"error": "... was removed ...", "code": "GONE"} while STILL being listed
+# in `onecli agents --help`. Help output is therefore not a usable capability
+# probe — we probe the live gateway instead and pick a path from the response.
+#
+# Callers use onecli_attach_secret_to_all_agents <secret_id> <onecli_url>.
+
+type log  >/dev/null 2>&1 || log()  { printf '[onecli-grants] %s\n' "$*"; }
+type warn >/dev/null 2>&1 || warn() { printf '[onecli-grants] WARN: %s\n' "$*" >&2; }
+
+# The onecli CLI exits non-zero on failure but ALSO prints {"error": ...} JSON.
+# Check both: a future version that keeps exiting 0 on error still gets caught.
+_onecli_json_error() {
+  printf '%s' "$1" | python3 -c "
+import sys, json
+try:
+  d = json.load(sys.stdin)
+except Exception:
+  sys.exit(0)
+if isinstance(d, dict) and d.get('error'):
+  print(d['error'])
+" 2>/dev/null || true
+}
+
+# Sets _ONECLI_GRANTS_API to "grants" or "legacy". Probes once per run.
+_onecli_detect_grants_api() {
+  [ -n "${_ONECLI_GRANTS_API:-}" ] && return 0
+
+  local probe_agent=$1 out err
+  out=$(onecli agents grants list --id "$probe_agent" 2>&1) || true
+  err=$(_onecli_json_error "$out")
+
+  if [ -z "$err" ] && printf '%s' "$out" | grep -q '"secrets"'; then
+    _ONECLI_GRANTS_API="grants"
+  else
+    _ONECLI_GRANTS_API="legacy"
+    warn "grants API unavailable ($err) — falling back to legacy set-secrets"
+    warn "if this OneCLI is current, upgrade the gateway rather than trusting the fallback"
+  fi
+}
+
+# Current API: read grants, attach only when missing.
+_onecli_attach_secret_grants() {
+  local agent_id=$1 agent_label=$2 secret_id=$3 out err
+
+  out=$(onecli agents grants list --id "$agent_id" 2>&1) || true
+  err=$(_onecli_json_error "$out")
+  if [ -n "$err" ]; then
+    warn "  agent '$agent_label': cannot read grants — $err"
+    return 1
+  fi
+
+  if printf '%s' "$out" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+ids = {s.get('secretId') for s in d.get('secrets', []) if isinstance(s, dict)}
+sys.exit(0 if '$secret_id' in ids else 1)
+" 2>/dev/null; then
+    log "  agent '$agent_label': already granted"
+    return 0
+  fi
+
+  out=$(onecli agents grants attach-secret --id "$agent_id" --secret-id "$secret_id" 2>&1) || true
+  err=$(_onecli_json_error "$out")
+  if [ -n "$err" ]; then
+    warn "  agent '$agent_label': attach-secret failed — $err"
+    return 1
+  fi
+  log "  agent '$agent_label': granted"
+}
+
+# Legacy API: set-secrets REPLACES the list, so read-append-write.
+_onecli_attach_secret_legacy() {
+  local agent_id=$1 agent_label=$2 secret_id=$3 current new_list out err
+
+  current=$(onecli agents secrets --id "$agent_id" 2>/dev/null | python3 -c "
+import sys, json
+try:
+  d = json.load(sys.stdin)
+  if isinstance(d, dict): d = d.get('data', [])
+  print(','.join(d))
+except Exception:
+  print('')
+" 2>/dev/null || echo "")
+
+  case ",$current," in
+    *",$secret_id,"*) log "  agent '$agent_label': already assigned"; return 0 ;;
+  esac
+
+  if [ -z "$current" ]; then
+    new_list="$secret_id"
+  else
+    new_list="${current},${secret_id}"
+  fi
+
+  out=$(onecli agents set-secrets --id "$agent_id" --secret-ids "$new_list" 2>&1) || true
+  err=$(_onecli_json_error "$out")
+  if [ -n "$err" ]; then
+    warn "  agent '$agent_label': set-secrets failed — $err"
+    return 1
+  fi
+  log "  agent '$agent_label': assigned"
+}
+
+# Attach $1 to every agent the gateway at $2 knows about.
+# Returns non-zero if any agent failed, so callers can surface a real error.
+onecli_attach_secret_to_all_agents() {
+  local secret_id=$1 onecli_url=$2 agents failures=0 aid aname
+
+  if [ -z "$secret_id" ]; then
+    warn "could not determine secret ID — skipping agent assignment"
+    return 1
+  fi
+
+  agents=$(curl -sf -m 5 "${onecli_url}/api/agents" 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if isinstance(d, dict): d = d.get('data', [])
+for a in d:
+  print(a.get('id', '') + '\t' + a.get('identifier', '?'))
+" 2>/dev/null || true)
+
+  if [ -z "$agents" ]; then
+    warn "no agents returned by ${onecli_url}/api/agents — nothing to grant"
+    return 1
+  fi
+
+  log "granting secret to all agents..."
+  # Fed by here-string, not a pipe, so the loop runs in this shell and
+  # failures actually reach the caller.
+  while IFS=$'\t' read -r aid aname; do
+    [ -n "$aid" ] || continue
+    _onecli_detect_grants_api "$aid"
+    if [ "$_ONECLI_GRANTS_API" = "grants" ]; then
+      _onecli_attach_secret_grants "$aid" "$aname" "$secret_id" || failures=$((failures + 1))
+    else
+      _onecli_attach_secret_legacy "$aid" "$aname" "$secret_id" || failures=$((failures + 1))
+    fi
+  done <<< "$agents"
+
+  if [ "$failures" -gt 0 ]; then
+    warn "$failures agent(s) did not receive the secret — containers using them will fail with 401"
+    return 1
+  fi
+}

--- a/scripts/migrate-anthropic-to-vault.sh
+++ b/scripts/migrate-anthropic-to-vault.sh
@@ -13,10 +13,11 @@
 # Idempotent: re-running detects the existing Vault secret and skips create.
 #
 # Exit codes:
-#   0 = secret registered (and optionally stripped from .env)
+#   0 = secret registered and granted to every agent
 #   1 = preflight failed (no onecli, no .env, no token, gateway down)
 #   2 = secret create call failed
 #   3 = python3 missing (required for JSON parsing)
+#   4 = secret registered but one or more agents were not granted access
 
 set -euo pipefail
 
@@ -39,6 +40,12 @@ done
 log()  { printf '[migrate-anthropic] %s\n' "$*"; }
 warn() { printf '[migrate-anthropic] WARN: %s\n' "$*" >&2; }
 fail() { printf '[migrate-anthropic] FAIL: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/onecli-grants.sh
+. "$SCRIPT_DIR/lib/onecli-grants.sh"
+
+GRANT_FAILED=0
 
 # --- Phase 0: prerequisites ---
 
@@ -131,65 +138,15 @@ for s in data:
   fi
 fi
 
-# --- Phase 2.5: assign secret to all detected agents ---
+# --- Phase 2.5: grant secret to all detected agents ---
 #
-# OneCLI's "all" secretMode does NOT auto-include secrets on injection
-# (verified empirically against v1.18.6). Each secret must be explicitly
-# assigned to each agent that should be able to use it. Doing so flips
-# the agent into "selective" mode automatically.
-#
-# Uses `onecli agents set-secrets` which REPLACES the list, so we
-# fetch current assignments first and append the new secret if missing.
+# Registering a secret does NOT make it usable. Each agent must be granted
+# the secret explicitly, or the gateway refuses injection and the container
+# sees a bare 401 ("credentials exist in OneCLI but this agent does not have
+# access"). Non-main groups authenticate as their own agent (see
+# agentIdentifier in src/container-runner.ts), so every agent needs the grant.
 
-assign_secret_to_agent() {
-  local agent_id=$1 agent_label=$2 secret_id=$3
-  # Fetch current secret IDs assigned to this agent
-  local current
-  current=$(onecli agents secrets --id "$agent_id" 2>/dev/null | python3 -c "
-import sys, json
-try:
-  d = json.load(sys.stdin)
-  if isinstance(d, dict): d = d.get('data', [])
-  print(','.join(d))
-except Exception:
-  print('')
-" 2>/dev/null || echo "")
-
-  # Already assigned?
-  case ",$current," in
-    *",$secret_id,"*) log "  agent '$agent_label': already assigned"; return 0 ;;
-  esac
-
-  # Build new list (append)
-  local new_list
-  if [ -z "$current" ]; then
-    new_list="$secret_id"
-  else
-    new_list="${current},${secret_id}"
-  fi
-
-  if onecli agents set-secrets --id "$agent_id" --secret-ids "$new_list" >/dev/null 2>&1; then
-    log "  agent '$agent_label': assigned"
-  else
-    warn "  agent '$agent_label': set-secrets failed"
-  fi
-}
-
-if [ -n "$SECRET_ID" ]; then
-  log "assigning secret to all agents..."
-  AGENTS_JSON=$(curl -sf -m 5 "${ONECLI_URL}/api/agents" 2>/dev/null || echo '[]')
-  printf '%s' "$AGENTS_JSON" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-if isinstance(d, dict): d = d.get('data', [])
-for a in d:
-  print(a.get('id', '') + '\t' + a.get('identifier', '?'))
-" 2>/dev/null | while IFS=$'\t' read -r aid aname; do
-    [ -n "$aid" ] && assign_secret_to_agent "$aid" "$aname" "$SECRET_ID"
-  done
-else
-  warn "could not determine secret ID — skipping agent assignment"
-fi
+onecli_attach_secret_to_all_agents "${SECRET_ID:-}" "$ONECLI_URL" || GRANT_FAILED=1
 
 # --- Phase 3: optionally strip the cred from .env ---
 
@@ -244,4 +201,11 @@ ROLLBACK (if anything breaks):
   sudo systemctl restart talon
 
 EOF
+fi
+
+if [ "$GRANT_FAILED" -ne 0 ]; then
+  warn "secret is in the Vault but NOT granted to every agent — those groups will 401."
+  warn "inspect with: onecli agents grants list --id <agent id from: onecli agents list>"
+  warn "grant with:   onecli agents grants attach-secret --id <agent id> --secret-id ${SECRET_ID:-<secret id>}"
+  exit 4
 fi

--- a/scripts/migrate-siem-to-vault.sh
+++ b/scripts/migrate-siem-to-vault.sh
@@ -20,10 +20,11 @@
 # name and skips the create call.
 #
 # Exit codes:
-#   0 = secret registered (and optionally stripped from siem/.env)
+#   0 = secret registered and granted to every agent
 #   1 = preflight failed (no onecli, no siem/.env, no creds, gateway down)
 #   2 = secret create call failed
 #   3 = python3 missing (required for JSON parsing)
+#   4 = secret registered but one or more agents were not granted access
 
 set -euo pipefail
 
@@ -47,6 +48,12 @@ done
 log()  { printf '[migrate-siem] %s\n' "$*"; }
 warn() { printf '[migrate-siem] WARN: %s\n' "$*" >&2; }
 fail() { printf '[migrate-siem] FAIL: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/onecli-grants.sh
+. "$SCRIPT_DIR/lib/onecli-grants.sh"
+
+GRANT_FAILED=0
 
 # --- Phase 0: prerequisites ---
 
@@ -141,53 +148,12 @@ for s in data:
   fi
 fi
 
-# --- Phase 3: assign secret to all detected agents ---
+# --- Phase 3: grant secret to all detected agents ---
+#
+# Registering a secret does NOT make it usable — each agent needs an explicit
+# grant or the gateway refuses injection. See scripts/lib/onecli-grants.sh.
 
-assign_secret_to_agent() {
-  local agent_id=$1 agent_label=$2 secret_id=$3
-  local current
-  current=$(onecli agents secrets --id "$agent_id" 2>/dev/null | python3 -c "
-import sys, json
-try:
-  d = json.load(sys.stdin)
-  if isinstance(d, dict): d = d.get('data', [])
-  print(','.join(d))
-except Exception:
-  print('')
-" 2>/dev/null || echo "")
-
-  case ",$current," in
-    *",$secret_id,"*) log "  agent '$agent_label': already assigned"; return 0 ;;
-  esac
-
-  local new_list
-  if [ -z "$current" ]; then
-    new_list="$secret_id"
-  else
-    new_list="${current},${secret_id}"
-  fi
-
-  if onecli agents set-secrets --id "$agent_id" --secret-ids "$new_list" >/dev/null 2>&1; then
-    log "  agent '$agent_label': assigned"
-  else
-    warn "  agent '$agent_label': set-secrets failed"
-  fi
-}
-
-if [ -n "$SECRET_ID" ]; then
-  log "assigning secret to all agents..."
-  curl -sf -m 5 "${ONECLI_URL}/api/agents" 2>/dev/null | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-if isinstance(d, dict): d = d.get('data', [])
-for a in d:
-  print(a.get('id', '') + '\t' + a.get('identifier', '?'))
-" 2>/dev/null | while IFS=$'\t' read -r aid aname; do
-    [ -n "$aid" ] && assign_secret_to_agent "$aid" "$aname" "$SECRET_ID"
-  done
-else
-  warn "could not determine secret ID — skipping agent assignment"
-fi
+onecli_attach_secret_to_all_agents "${SECRET_ID:-}" "$ONECLI_URL" || GRANT_FAILED=1
 
 # --- Phase 4: optionally strip the cred from siem/.env ---
 
@@ -246,4 +212,11 @@ ROLLBACK (if anything breaks):
   sudo systemctl restart talon
 
 EOF
+fi
+
+if [ "$GRANT_FAILED" -ne 0 ]; then
+  warn "secret is in the Vault but NOT granted to every agent — those groups will 401."
+  warn "inspect with: onecli agents grants list --id <agent id from: onecli agents list>"
+  warn "grant with:   onecli agents grants attach-secret --id <agent id> --secret-id ${SECRET_ID:-<secret id>}"
+  exit 4
 fi


### PR DESCRIPTION
The vault migration scripts assigned secrets with `onecli agents secrets` and `onecli agents set-secrets`. OneCLI replaced both with a grants model and the old endpoints now answer {"code": "GONE"}, so migrations silently granted nothing and containers failed with:

  401 api.anthropic.com credentials exist in OneCLI but this agent does
  not have access

Two bugs hid the failure: the set-secrets call discarded its output and exit status via `>/dev/null 2>&1` and only warned, and the assignment loop ran inside a pipeline so its subshell status was dropped. The script reported success either way.

Extract the duplicated assign_secret_to_agent from both migration scripts into scripts/lib/onecli-grants.sh, ported to `agents grants list` / `attach-secret`. The helper probes the live gateway to pick its API — `onecli agents --help` still lists the removed subcommands, so help output is not a usable capability check — and falls back to the legacy path for older gateways. Failures now surface: the helper checks both exit status and the {"error": ...} body, the loop is fed by a here-string so failures reach the caller, and both scripts exit 4 when any agent is left without access.

Non-main groups authenticate as their own agent (agentIdentifier in src/container-runner.ts), so a missing grant can break one group while others keep working. Documented that in the README and added a debug checklist entry for the 401.

Tested against a live OneCLI gateway: already-granted (idempotent, exit 0), bogus secret id (3 warns, exit 1), empty secret id (skip, exit 1), detach-then-rerun (attaches only the missing agent, exit 0), and a full migrate-anthropic-to-vault.sh run (exit 0, all agents granted). Verified lib path resolution from a foreign cwd; bash -n clean on all three files.

<!-- contributing-guide: v1 -->
## Type of Change

- [ ] **Feature skill** - adds a channel or integration (source code changes + SKILL.md)
- [ ] **Utility skill** - adds a standalone tool (code files in `.claude/skills/<name>/`, no source changes)
- [ ] **Operational/container skill** - adds a workflow or agent skill (SKILL.md only, no source changes)
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code
- [ ] **Documentation** - docs, README, or CONTRIBUTING changes only

## Description


## For Skills

- [ ] SKILL.md contains instructions, not inline code (code goes in separate files)
- [ ] SKILL.md is under 500 lines
- [ ] I tested this skill on a fresh clone
