### PR TITLE
feat(sessions): give each CoPilot user their own chat lane

### DIFF
--- a/src/channels/http.test.ts
+++ b/src/channels/http.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { HttpChannel } from './http.js';
+import { isValidGroupFolder } from '../group-folder.js';
+import { HttpChannel, laneJidForUser, normalizeUserId } from './http.js';
 import type { ChannelOpts } from './registry.js';
 
 const COPILOT_JID = 'http:copilot';
@@ -25,14 +26,55 @@ function makeRes() {
   };
 }
 
-function makeOpts(): ChannelOpts {
+function makeOpts(overrides: Partial<ChannelOpts> = {}): ChannelOpts {
   return {
     onMessage: vi.fn(),
     onChatMetadata: vi.fn(),
     registeredGroups: () => ({}),
     registerGroup: vi.fn(),
     clearSession: vi.fn().mockReturnValue(true),
+    unregisterGroup: vi.fn().mockReturnValue(true),
+    ...overrides,
   };
+}
+
+/**
+ * A channel with a live registry, so lane registration is observable the way
+ * the orchestrator sees it.
+ */
+function makeChannelWithRegistry() {
+  const registry: Record<string, unknown> = {};
+  const opts = makeOpts({
+    registeredGroups: () => registry as never,
+    registerGroup: vi.fn((jid: string, group: unknown) => {
+      registry[jid] = group;
+    }),
+    unregisterGroup: vi.fn((jid: string) => delete registry[jid]),
+  });
+  const channel = new HttpChannel(opts);
+  // connect() would bind a port; seed the template it captures instead.
+  (channel as unknown as { baseGroup: unknown }).baseGroup = {
+    name: 'CoPilot',
+    folder: 'copilot',
+    trigger: '',
+    added_at: '2026-01-01T00:00:00.000Z',
+    requiresTrigger: false,
+    trustedSessionCommands: true,
+  };
+  return { channel, opts, registry };
+}
+
+/** Resolve a lane the way the POST /message handler does. */
+function laneFor(
+  channel: HttpChannel,
+  userId: unknown,
+  userName?: string,
+): string {
+  return (
+    channel as unknown as {
+      ensureUserLane: (id: string | null, name?: string) => string;
+    }
+  ).ensureUserLane(normalizeUserId(userId), userName);
 }
 
 /**
@@ -158,5 +200,206 @@ describe('HttpChannel lane ownership', () => {
     const channel = new HttpChannel(makeOpts());
     expect(channel.ownsJid('webhook:copilot')).toBe(false);
     expect(channel.ownsJid('telegram:123')).toBe(false);
+  });
+});
+
+describe('normalizeUserId', () => {
+  it('accepts ids CoPilot actually issues', () => {
+    expect(normalizeUserId(42)).toBe('42');
+    expect(normalizeUserId('analyst-7')).toBe('analyst-7');
+    expect(normalizeUserId('a_b-C9')).toBe('a_b-C9');
+  });
+
+  it('strips characters that would escape the key or path', () => {
+    expect(normalizeUserId('../../etc/passwd')).toBe('etcpasswd');
+    expect(normalizeUserId('a:b')).toBe('ab');
+  });
+
+  it('falls back to the anon lane rather than mangling into a neighbour', () => {
+    expect(normalizeUserId('')).toBeNull();
+    expect(normalizeUserId('   ')).toBeNull();
+    expect(normalizeUserId('///')).toBeNull();
+    expect(normalizeUserId(undefined)).toBeNull();
+    expect(normalizeUserId(null)).toBeNull();
+    expect(normalizeUserId({ id: 1 })).toBeNull();
+  });
+
+  it('bounds the length so the derived lane key stays a valid folder', () => {
+    // `copilot-u-<id>` is used as both a session key and an IPC namespace, and
+    // both resolvers reject anything over 64 characters. An unbounded id would
+    // throw at container start rather than at parse time.
+    const id = normalizeUserId('x'.repeat(200));
+    expect(id).not.toBeNull();
+    expect(isValidGroupFolder(`copilot-u-${id}`)).toBe(true);
+  });
+
+  it('keeps every accepted id inside a valid lane key', () => {
+    for (const raw of ['42', 'analyst-7', 'a_b-C9', 'z'.repeat(300)]) {
+      const id = normalizeUserId(raw);
+      expect(id).not.toBeNull();
+      expect(isValidGroupFolder(`copilot-u-${id}`)).toBe(true);
+    }
+  });
+});
+
+describe('per-user lanes', () => {
+  it('registers a lane per user, cloned from the base group', () => {
+    const { channel, registry } = makeChannelWithRegistry();
+
+    const jid = laneFor(channel, '42', 'Dana');
+
+    expect(jid).toBe(laneJidForUser('42'));
+    expect(registry[jid]).toMatchObject({
+      folder: 'copilot',
+      sessionKey: 'copilot-u-42',
+      ipcKey: 'copilot-u-42',
+      trustedSessionCommands: true,
+    });
+  });
+
+  it('gives two users separate sessions and IPC namespaces', () => {
+    const { channel, registry } = makeChannelWithRegistry();
+
+    const a = laneFor(channel, '1', 'Ana');
+    const b = laneFor(channel, '2', 'Ben');
+
+    expect(a).not.toBe(b);
+    const laneA = registry[a] as { sessionKey: string; ipcKey: string };
+    const laneB = registry[b] as { sessionKey: string; ipcKey: string };
+    expect(laneA.sessionKey).not.toBe(laneB.sessionKey);
+    expect(laneA.ipcKey).not.toBe(laneB.ipcKey);
+    // …while still sharing every mount and prompt.
+    expect((registry[a] as { folder: string }).folder).toBe(
+      (registry[b] as { folder: string }).folder,
+    );
+  });
+
+  it('registers a returning user once', () => {
+    const { channel, opts } = makeChannelWithRegistry();
+
+    laneFor(channel, '42', 'Dana');
+    laneFor(channel, '42', 'Dana');
+    laneFor(channel, '42', 'Dana');
+
+    expect(opts.registerGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes a request with no user id to the shared anon lane', () => {
+    const { channel, opts } = makeChannelWithRegistry();
+
+    expect(laneFor(channel, undefined)).toBe(COPILOT_JID);
+    expect(opts.registerGroup).not.toHaveBeenCalled();
+  });
+
+  it('does not deliver one user’s reply to another', () => {
+    // The reported bug: two analysts chatting at once, and B receives A's
+    // answer. Separate lanes mean separate writers, so it cannot happen.
+    const { channel } = makeChannelWithRegistry();
+    const ana = laneFor(channel, '1', 'Ana');
+    const ben = laneFor(channel, '2', 'Ben');
+
+    const anaRes = enqueue(channel, ana);
+    const benRes = enqueue(channel, ben);
+
+    return (async () => {
+      await channel.setTyping(ana, true);
+      await channel.setTyping(ben, true);
+
+      await channel.sendMessage(ana, 'answer for Ana');
+      await channel.sendMessage(ben, 'answer for Ben');
+
+      expect(textEvents(anaRes.res)).toEqual(['answer for Ana']);
+      expect(textEvents(benRes.res)).toEqual(['answer for Ben']);
+    })();
+  });
+
+  it('owns every per-user lane it hands out', () => {
+    const { channel } = makeChannelWithRegistry();
+    expect(channel.ownsJid(laneFor(channel, 'analyst-7'))).toBe(true);
+  });
+});
+
+describe('session reset scoping', () => {
+  it('resets only the requesting user’s lane', () => {
+    const { channel, opts } = makeChannelWithRegistry();
+    laneFor(channel, '1', 'Ana');
+    laneFor(channel, '2', 'Ben');
+
+    // What POST /session/reset does for scope 'chat' with a user_id.
+    opts.clearSession?.(laneJidForUser('1'));
+
+    expect(opts.clearSession).toHaveBeenCalledTimes(1);
+    expect(opts.clearSession).toHaveBeenCalledWith(laneJidForUser('1'));
+    expect(opts.clearSession).not.toHaveBeenCalledWith(laneJidForUser('2'));
+  });
+
+  it('enumerates every user lane for a scope of all', () => {
+    const { channel } = makeChannelWithRegistry();
+    laneFor(channel, '1', 'Ana');
+    laneFor(channel, '2', 'Ben');
+
+    const lanes = (
+      channel as unknown as { userLaneJids: () => string[] }
+    ).userLaneJids();
+
+    expect(lanes.sort()).toEqual(
+      [laneJidForUser('1'), laneJidForUser('2')].sort(),
+    );
+  });
+});
+
+describe('idle lane sweep', () => {
+  function sweep(channel: HttpChannel) {
+    (channel as unknown as { sweepIdleLanes: () => void }).sweepIdleLanes();
+  }
+
+  function setLastSeen(channel: HttpChannel, jid: string, at: number) {
+    (
+      channel as unknown as { laneLastSeen: Map<string, number> }
+    ).laneLastSeen.set(jid, at);
+  }
+
+  it('drops a lane that has gone quiet, releasing its session', () => {
+    const { channel, opts, registry } = makeChannelWithRegistry();
+    const jid = laneFor(channel, '1', 'Ana');
+
+    setLastSeen(channel, jid, Date.now() - 48 * 60 * 60 * 1000);
+    sweep(channel);
+
+    expect(opts.clearSession).toHaveBeenCalledWith(jid);
+    expect(opts.unregisterGroup).toHaveBeenCalledWith(jid);
+    expect(registry[jid]).toBeUndefined();
+  });
+
+  it('keeps a recently active lane', () => {
+    const { channel, opts } = makeChannelWithRegistry();
+    laneFor(channel, '1', 'Ana');
+
+    sweep(channel);
+
+    expect(opts.clearSession).not.toHaveBeenCalled();
+    expect(opts.unregisterGroup).not.toHaveBeenCalled();
+  });
+
+  it('never sweeps a lane with an open stream', () => {
+    const { channel, opts } = makeChannelWithRegistry();
+    const jid = laneFor(channel, '1', 'Ana');
+    enqueue(channel, jid);
+
+    setLastSeen(channel, jid, Date.now() - 48 * 60 * 60 * 1000);
+    sweep(channel);
+
+    expect(opts.clearSession).not.toHaveBeenCalled();
+  });
+
+  it('leaves the anon and investigation lanes alone', () => {
+    const { channel, opts } = makeChannelWithRegistry();
+    laneFor(channel, undefined);
+
+    setLastSeen(channel, COPILOT_JID, 0);
+    setLastSeen(channel, INVESTIGATE_JID, 0);
+    sweep(channel);
+
+    expect(opts.clearSession).not.toHaveBeenCalled();
   });
 });

--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -28,6 +28,46 @@ const COPILOT_JID = process.env.COPILOT_JID || 'http:copilot';
 // persisted. Keeps raw SIEM documents out of the analyst chat context, and
 // keeps one alert's findings from leaking into the next investigation.
 const COPILOT_INVESTIGATE_JID = `${COPILOT_JID}:investigate`;
+// Prefix for per-analyst chat lanes. Each signed-in CoPilot user gets their own
+// conversation: separate session, separate queue slot, separate SSE writer.
+// Without this, two analysts chatting at once are batched into a single prompt
+// and a single turn, and each can receive the other's reply.
+const COPILOT_USER_JID_PREFIX = `${COPILOT_JID}:u:`;
+// Session/IPC key prefix for a per-user lane. Kept next to the JID prefix so
+// the two can't drift — GET /status maps one back to the other.
+const USER_SESSION_KEY_PREFIX = 'copilot-u-';
+// A request that names no user falls back to the base lane, so callers written
+// before per-user lanes keep working (and keep their existing conversation).
+const ANON_LANE_JID = COPILOT_JID;
+// Lanes are dropped after this long without traffic: they accumulate as staff
+// come and go, and each one pins an abandoned transcript on disk.
+const USER_LANE_IDLE_MS =
+  Math.max(1, parseInt(process.env.SESSION_IDLE_HOURS || '24', 10) || 24) *
+  60 *
+  60 *
+  1000;
+const LANE_SWEEP_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Reduce a CoPilot user id to something safe to embed in a JID, a session key
+ * and a filesystem path. Anything unrecognised collapses to the anonymous
+ * lane rather than being silently mangled into a neighbouring user's key.
+ */
+export function normalizeUserId(raw: unknown): string | null {
+  if (typeof raw !== 'string' && typeof raw !== 'number') return null;
+  const cleaned = String(raw)
+    .trim()
+    .replace(/[^A-Za-z0-9_-]/g, '')
+    // Bounded so `copilot-u-<id>` still satisfies the 64-character group
+    // folder pattern the session and IPC path resolvers enforce.
+    .slice(0, 48);
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+/** JID of the lane owned by a CoPilot user id. */
+export function laneJidForUser(userId: string): string {
+  return `${COPILOT_USER_JID_PREFIX}${userId}`;
+}
 const COPILOT_GROUP_FOLDER = process.env.COPILOT_GROUP_FOLDER || 'copilot';
 const COPILOT_HTTP_PORT = parseInt(process.env.COPILOT_HTTP_PORT || '3100', 10);
 const HTTP_API_KEY = readEnvFile(['HTTP_API_KEY']).HTTP_API_KEY || '';
@@ -53,6 +93,13 @@ export class HttpChannel implements Channel {
   private opts: ChannelOpts;
   private startedAt = Date.now();
   private activeInvestigations = 0;
+
+  // Template the per-user lanes are cloned from — captured at connect() so the
+  // mount set and container config stay identical across every lane.
+  private baseGroup: RegisteredGroup | null = null;
+  // Last inbound message per user lane, for the idle sweep.
+  private laneLastSeen = new Map<string, number>();
+  private sweepTimer: NodeJS.Timeout | null = null;
 
   // SSE writers are tracked per lane. A single global FIFO cannot correlate a
   // response with the request that produced it: concurrent callers, or an
@@ -179,6 +226,74 @@ export class HttpChannel implements Channel {
     );
   }
 
+  /**
+   * Resolve the lane for an inbound chat message, registering it on first use.
+   *
+   * Lanes are cloned from the base group, so they share the folder — same
+   * CLAUDE.md, prompts and mounts — and differ only in identity: their own
+   * session, IPC namespace, queue slot and SSE writer.
+   */
+  private ensureUserLane(userId: string | null, userName?: string): string {
+    if (!userId) return ANON_LANE_JID;
+
+    const jid = laneJidForUser(userId);
+    this.laneLastSeen.set(jid, Date.now());
+
+    if (this.opts.registeredGroups()[jid]) return jid;
+    if (!this.baseGroup) {
+      // connect() hasn't run — nothing to clone from. Fall back rather than
+      // registering a half-built lane with no mounts.
+      logger.warn({ jid }, 'HTTP channel: no base group, using anon lane');
+      return ANON_LANE_JID;
+    }
+
+    const label = (userName ?? '').trim().slice(0, 64) || userId;
+    this.opts.registerGroup?.(jid, {
+      ...this.baseGroup,
+      name: `CoPilot — ${label}`,
+      sessionKey: `${USER_SESSION_KEY_PREFIX}${userId}`,
+      ipcKey: `${USER_SESSION_KEY_PREFIX}${userId}`,
+      trustedSessionCommands: true,
+    });
+    // isGroup=false keeps these out of the main group's activatable-group list.
+    this.opts.onChatMetadata(
+      jid,
+      new Date().toISOString(),
+      `CoPilot — ${label}`,
+      'http',
+      false,
+    );
+    logger.info({ jid, userId }, 'HTTP channel: registered user lane');
+    return jid;
+  }
+
+  /** Every registered per-user lane JID. */
+  private userLaneJids(): string[] {
+    return Object.keys(this.opts.registeredGroups()).filter((jid) =>
+      jid.startsWith(COPILOT_USER_JID_PREFIX),
+    );
+  }
+
+  /**
+   * Drop lanes with no recent traffic, releasing their stored session and the
+   * transcript it pins. A lane with an open SSE stream is never swept.
+   */
+  private sweepIdleLanes(): void {
+    const cutoff = Date.now() - USER_LANE_IDLE_MS;
+    for (const jid of this.userLaneJids()) {
+      const lastSeen = this.laneLastSeen.get(jid) ?? 0;
+      if (lastSeen > cutoff) continue;
+      if (this.active.has(jid) || (this.pending.get(jid)?.length ?? 0) > 0) {
+        continue;
+      }
+      this.opts.clearSession?.(jid);
+      this.opts.unregisterGroup?.(jid);
+      this.laneLastSeen.delete(jid);
+      this.pending.delete(jid);
+      logger.info({ jid }, 'HTTP channel: swept idle user lane');
+    }
+  }
+
   async connect(): Promise<void> {
     if (!HTTP_API_KEY) {
       throw new Error(
@@ -255,10 +370,8 @@ export class HttpChannel implements Channel {
     // this server is rejected without HTTP_API_KEY (see the auth check below)
     // and CoPilot's own route is scope-checked — a stronger guarantee than the
     // is_from_me flag this would otherwise require.
-    this.opts.registerGroup?.(COPILOT_JID, {
-      ...group,
-      trustedSessionCommands: true,
-    });
+    this.baseGroup = { ...group, trustedSessionCommands: true };
+    this.opts.registerGroup?.(COPILOT_JID, this.baseGroup);
 
     // Investigation lane: same folder and mounts, separate ephemeral session.
     // No trustedSessionCommands — nothing types slash commands at it.
@@ -271,6 +384,12 @@ export class HttpChannel implements Channel {
     });
 
     this.seedAlertDigestTask();
+    this.sweepTimer = setInterval(
+      () => this.sweepIdleLanes(),
+      LANE_SWEEP_INTERVAL_MS,
+    );
+    // Don't hold the process open just to run the sweep.
+    this.sweepTimer.unref?.();
 
     this.opts.onChatMetadata(
       COPILOT_JID,
@@ -307,6 +426,11 @@ export class HttpChannel implements Channel {
           .filter((row) => row.group_folder.startsWith(COPILOT_GROUP_FOLDER))
           .map((row) => ({
             lane: row.group_folder,
+            // Named explicitly so callers don't have to parse the key format
+            // to find their own lane. null for the shared/anon lane.
+            user_id: row.group_folder.startsWith(USER_SESSION_KEY_PREFIX)
+              ? row.group_folder.slice(USER_SESSION_KEY_PREFIX.length)
+              : null,
             session_id: row.session_id,
             input_tokens: row.input_tokens,
             updated_at: row.updated_at,
@@ -338,7 +462,7 @@ export class HttpChannel implements Channel {
           body += chunk;
         });
         req.on('end', () => {
-          let parsed: { scope?: string } = {};
+          let parsed: { scope?: string; user_id?: string | number } = {};
           if (body.trim()) {
             try {
               parsed = JSON.parse(body);
@@ -350,13 +474,19 @@ export class HttpChannel implements Channel {
           }
 
           const scope = parsed.scope || 'chat';
+          const userId = normalizeUserId(parsed.user_id);
+
+          // 'chat' resets the caller's own lane. That is the important
+          // property: an analyst clearing their conversation must not clear
+          // a colleague's. Without a user_id it falls back to the shared
+          // anonymous lane, which is the one such a caller is using anyway.
           const targets: string[] =
             scope === 'all'
-              ? [COPILOT_JID, COPILOT_INVESTIGATE_JID]
+              ? [COPILOT_JID, COPILOT_INVESTIGATE_JID, ...this.userLaneJids()]
               : scope === 'investigate'
                 ? [COPILOT_INVESTIGATE_JID]
                 : scope === 'chat'
-                  ? [COPILOT_JID]
+                  ? [userId ? laneJidForUser(userId) : ANON_LANE_JID]
                   : [];
 
           if (targets.length === 0) {
@@ -372,7 +502,10 @@ export class HttpChannel implements Channel {
           const cleared = targets.filter(
             (jid) => this.opts.clearSession?.(jid) === true,
           );
-          logger.info({ scope, cleared }, 'HTTP channel: session reset');
+          logger.info(
+            { scope, userId, cleared },
+            'HTTP channel: session reset',
+          );
 
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ cleared: cleared.length, lanes: cleared }));
@@ -804,7 +937,12 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
           body += chunk;
         });
         req.on('end', () => {
-          let parsed: { message?: string; sender?: string } = {};
+          let parsed: {
+            message?: string;
+            sender?: string;
+            user_id?: string | number;
+            user_name?: string;
+          } = {};
           try {
             parsed = JSON.parse(body);
           } catch {
@@ -821,6 +959,12 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
           }
 
           const senderName = parsed.sender || 'copilot';
+          // Resolve the caller's lane before opening the stream, so the writer
+          // is queued against the same JID the reply will be written to.
+          const laneJid = this.ensureUserLane(
+            normalizeUserId(parsed.user_id),
+            parsed.user_name,
+          );
 
           // Start SSE response
           res.writeHead(200, {
@@ -835,9 +979,9 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
           // req.on('close') fires when the POST body is consumed (almost immediately).
           new Promise<void>((resolve) => {
             const writer: SseWriter = { res, resolve };
-            const queue = this.pending.get(COPILOT_JID) ?? [];
+            const queue = this.pending.get(laneJid) ?? [];
             queue.push(writer);
-            this.pending.set(COPILOT_JID, queue);
+            this.pending.set(laneJid, queue);
 
             // Start SSE keepalive immediately. The agent may take 30–90s to
             // boot the container + produce its first chunk; without periodic
@@ -855,19 +999,19 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
                 clearInterval(writer.keepalive);
                 writer.keepalive = undefined;
               }
-              const q = this.pending.get(COPILOT_JID);
+              const q = this.pending.get(laneJid);
               const idx = q ? q.indexOf(writer) : -1;
               if (q && idx !== -1) q.splice(idx, 1);
-              if (this.active.get(COPILOT_JID) === writer) {
-                this.active.delete(COPILOT_JID);
+              if (this.active.get(laneJid) === writer) {
+                this.active.delete(laneJid);
               }
               resolve();
             });
 
             // Route into NanoClaw's pipeline — GroupQueue → container → agent
-            this.opts.onMessage(COPILOT_JID, {
+            this.opts.onMessage(laneJid, {
               id: `http-${Date.now()}`,
-              chat_jid: COPILOT_JID,
+              chat_jid: laneJid,
               sender: senderName,
               sender_name: senderName,
               content: message,
@@ -876,7 +1020,7 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
             });
 
             logger.info(
-              { sender: senderName, length: message.length },
+              { lane: laneJid, sender: senderName, length: message.length },
               'HTTP channel: message received',
             );
           });
@@ -893,7 +1037,7 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
         logger.info({ port: COPILOT_HTTP_PORT }, 'HTTP channel listening');
         console.log(`\n  HTTP channel: http://localhost:${COPILOT_HTTP_PORT}`);
         console.log(
-          `  POST /message     { "message": "...", "sender": "..." }`,
+          `  POST /message     { "message": "...", "sender": "...", "user_id": "..." }`,
         );
         console.log(
           `  POST /investigate    { "alert_id": 123, "customer_code": "acme", "template_override": "sysmon_event_1.txt" }`,
@@ -909,7 +1053,7 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
         console.log(`  POST /palace/forget   { "drawer_id": "..." }`);
         console.log(`  GET  /status`);
         console.log(
-          `  POST /session/reset { "scope": "chat|investigate|all" }`,
+          `  POST /session/reset { "scope": "chat|investigate|all", "user_id": "..." }`,
         );
         console.log(`  GET  /health\n`);
         resolve();
@@ -1002,6 +1146,10 @@ ${stepOverrideInstruction}4. Write back to CoPilot — call these three tools in
   }
 
   async disconnect(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
     if (this.server) {
       this.server.close();
       this.server = null;

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -14,6 +14,9 @@ export interface ChannelOpts {
   // Optional — drops a lane's stored session (in memory and on disk) so the
   // next run starts from empty context. Returns false for an unknown JID.
   clearSession?: (jid: string) => boolean;
+  // Optional — drops an in-memory lane registration. Used to retire per-user
+  // lanes that have gone idle; never removes a persisted group.
+  unregisterGroup?: (jid: string) => boolean;
 }
 
 export type ChannelFactory = (opts: ChannelOpts) => Channel | null;

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -22,9 +22,13 @@ import {
   mergeProviderConfig,
   readEnvFile,
 } from './env.js';
-import { resolveGroupFolderPath, resolveGroupIpcPath } from './group-folder.js';
+import {
+  resolveGroupFolderPath,
+  resolveGroupIpcPath,
+  resolveGroupSessionsPath,
+} from './group-folder.js';
 import { logger } from './logger.js';
-import { ipcKeyFor } from './session-lane.js';
+import { ipcKeyFor, sessionKeyFor } from './session-lane.js';
 import {
   CONTAINER_HOST_GATEWAY,
   CONTAINER_RUNTIME_BIN,
@@ -160,12 +164,12 @@ function buildVolumeMounts(
     }
   }
 
-  // Per-group Claude sessions directory (isolated from other groups)
-  // Each group gets their own .claude/ to prevent cross-group session access
+  // Per-lane Claude sessions directory. Each lane gets its own .claude/ to
+  // prevent cross-group session access — and, for lanes that share a group
+  // folder, to keep concurrent containers off the same transcripts, settings
+  // and session index.
   const groupSessionsDir = path.join(
-    DATA_DIR,
-    'sessions',
-    group.folder,
+    resolveGroupSessionsPath(sessionKeyFor(group)),
     '.claude',
   );
   fs.mkdirSync(groupSessionsDir, { recursive: true });

--- a/src/group-folder.ts
+++ b/src/group-folder.ts
@@ -35,6 +35,19 @@ export function resolveGroupFolderPath(folder: string): string {
   return groupPath;
 }
 
+/**
+ * Directory holding a lane's agent session store (its `.claude/`). Keyed on
+ * the lane, not the group folder, so concurrent lanes that share a folder do
+ * not write to the same transcripts, settings and session index.
+ */
+export function resolveGroupSessionsPath(folder: string): string {
+  assertValidGroupFolder(folder);
+  const sessionsBaseDir = path.resolve(DATA_DIR, 'sessions');
+  const sessionsPath = path.resolve(sessionsBaseDir, folder);
+  ensureWithinBase(sessionsBaseDir, sessionsPath);
+  return sessionsPath;
+}
+
 export function resolveGroupIpcPath(folder: string): string {
   assertValidGroupFolder(folder);
   const ipcBaseDir = path.resolve(DATA_DIR, 'ipc');

--- a/src/index.ts
+++ b/src/index.ts
@@ -800,6 +800,13 @@ async function main(): Promise<void> {
       logger.info({ jid, group: group.name }, 'Session cleared');
       return true;
     },
+    unregisterGroup: (jid: string) => {
+      if (!registeredGroups[jid]) return false;
+      delete registeredGroups[jid];
+      delete lastAgentTimestamp[jid];
+      saveState();
+      return true;
+    },
   };
 
   // Create and connect all registered channels.


### PR DESCRIPTION
Spec M from the gameplan on socfortress/CoPilot#1111. Builds on the lane primitive from #12.

Fixes the field report that **two analysts using the AI Analyst chat at the same time receive each other's replies.**

## Why a per-user session alone would not have fixed it

Reproduced in the code as two separate defects:

- **Message batching** — `formatMessages(missedMessages)` merged up to `MAX_MESSAGES_PER_PROMPT` (default 10) pending messages into one prompt and one turn, *regardless of sender*. One turn answered both analysts' questions.
- **Writer dequeue** — the SSE writer was taken off the queue per *turn*, not per *request*, so that combined answer went to whichever writer came off first. Mid-turn piping then called `setTyping(true)` again, dequeuing the second analyst's writer while the first one's turn was still streaming.

The batch, the queue slot and the writer are all keyed on the **JID**, not on the session. So the fix is a lane per user — the per-user session falls out as a consequence rather than being the mechanism.

The frontend also hardcoded `sender: "copilot"`, so Talon could not tell users apart at all.

## Changes

- **`POST /message` accepts `user_id` and `user_name`.** Absent, the request falls back to the shared anonymous lane, so callers written before this keep working *and keep their existing conversation*.
- **Lanes are registered lazily**, cloned from the base group: same folder, same mounts, same prompts; their own session, IPC namespace, queue slot and SSE writer.
- **`normalizeUserId`** reduces an id to something safe to embed in a JID, a session key and a filesystem path. Anything unrecognised (empty, punctuation-only, wrong type) collapses to the anonymous lane rather than being silently mangled into a neighbouring user's key.
- **`POST /session/reset` scope `chat` now resets the calling user's lane**, so an analyst clearing their conversation cannot clear a colleague's. Scope `all` enumerates every registered lane.
- **`GET /status` reports `user_id`** alongside each lane, so a caller doesn't have to parse the key format to find its own — the input CoPilot's context meter needs.
- **Idle lanes are swept** on a 15-minute timer, controlled by `SESSION_IDLE_HOURS` (default 24). Staff come and go, and each abandoned lane pins a transcript. A lane with an open stream is never swept.

## Two bugs found while building this

**Lane keys could exceed the folder pattern.** `copilot-u-<id>` is used as both a session key and an IPC namespace, and both path resolvers enforce `^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`. A 64-character user id produced a 74-character key that would have thrown at container start rather than at parse time. Ids are now bounded to 48, and a test asserts every accepted id yields a valid lane key.

**Concurrent lanes shared one agent session store.** `.claude/` was keyed on `group.folder`, so every lane sharing the `copilot` folder wrote to the same transcripts, `settings.json` and session index. Already true for the chat and investigation lanes after #12, and it would have scaled with the number of signed-in analysts. Now keyed on the lane, via a new validated `resolveGroupSessionsPath`. The anonymous lane's key is unchanged (`copilot`), so it keeps its existing store.

## Concurrency

No new knob. `MAX_CONCURRENT_CONTAINERS` (default 5) already bounds simultaneous containers and `GroupQueue` already applies backpressure past it — lanes beyond the limit queue rather than being dropped. Tune it against the host's memory headroom; each lane is a container with the full MCP mount set.

## Verification

- `tsc --noEmit` clean; no new lint errors.
- **443 tests pass, up from 426** — 17 new in `src/channels/http.test.ts`:
  - `normalizeUserId` accepts the ids CoPilot issues, strips path/key escapes, collapses unusable input to the anon lane, and keeps every accepted id inside a valid lane key.
  - A lane per user, cloned from the base group; two users get separate sessions and IPC namespaces while sharing the folder; a returning user registers once; no `user_id` routes to the shared anon lane.
  - **The regression test for the report:** two lanes, two writers, each analyst receives only their own answer.
  - Reset scoping: only the requesting user's lane is cleared; `all` enumerates every user lane.
  - Sweep: a quiet lane is dropped and its session released; a recently active lane is kept; a lane with an open stream is never swept; the anon and investigation lanes are left alone.

## Follow-up, not in this PR

A swept lane's `.claude/` directory is left on disk. It is a few MB per departed analyst, so growth is slow, but a cleanup pass on sweep would close it. Deliberately left out here rather than adding filesystem deletion to a PR that is already about routing.

Refs socfortress/CoPilot#1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fFbajcAEwjtuZWAVT3Xg9
