### PR TITLE
fix(sessions): register the investigation lane's chat row

### DIFF
--- a/src/channels/http.test.ts
+++ b/src/channels/http.test.ts
@@ -319,6 +319,51 @@ describe('per-user lanes', () => {
   });
 });
 
+describe('lane registration', () => {
+  function registerLane(channel: HttpChannel, jid: string, name: string) {
+    (
+      channel as unknown as {
+        registerLane: (jid: string, group: unknown) => void;
+      }
+    ).registerLane(jid, { name, folder: 'copilot' });
+  }
+
+  it('creates the chat row alongside the group entry', () => {
+    // Registering a lane without its chat row makes the first inbound message
+    // fail a foreign key inside the request handler, so the caller gets a
+    // closed connection instead of a response. Both writes, always together.
+    const { channel, opts } = makeChannelWithRegistry();
+
+    registerLane(channel, INVESTIGATE_JID, 'CoPilot Investigations');
+
+    expect(opts.registerGroup).toHaveBeenCalledWith(
+      INVESTIGATE_JID,
+      expect.objectContaining({ name: 'CoPilot Investigations' }),
+    );
+    expect(opts.onChatMetadata).toHaveBeenCalledWith(
+      INVESTIGATE_JID,
+      expect.any(String),
+      'CoPilot Investigations',
+      'http',
+      false,
+    );
+  });
+
+  it('registers a chat row for every user lane it hands out', () => {
+    const { channel, opts } = makeChannelWithRegistry();
+
+    const jid = laneFor(channel, '42', 'Dana');
+
+    expect(opts.onChatMetadata).toHaveBeenCalledWith(
+      jid,
+      expect.any(String),
+      'CoPilot — Dana',
+      'http',
+      false,
+    );
+  });
+});
+
 describe('session reset scoping', () => {
   it('resets only the requesting user’s lane', () => {
     const { channel, opts } = makeChannelWithRegistry();

--- a/src/channels/http.ts
+++ b/src/channels/http.ts
@@ -227,6 +227,29 @@ export class HttpChannel implements Channel {
   }
 
   /**
+   * Register a lane: its group entry AND its chat row, always together.
+   *
+   * `messages.chat_jid` is a foreign key into `chats(jid)`, and foreign keys
+   * are enforced. A lane registered as a group but missing its chat row
+   * cannot store an inbound message — `storeMessage` throws inside the
+   * request handler, before a response is written, so the caller sees the
+   * connection close rather than an error. Keeping both writes in one place
+   * is what stops the two from drifting apart again.
+   *
+   * isGroup=false keeps these out of the main group's activatable-group list.
+   */
+  private registerLane(jid: string, group: RegisteredGroup): void {
+    this.opts.registerGroup?.(jid, group);
+    this.opts.onChatMetadata(
+      jid,
+      new Date().toISOString(),
+      group.name,
+      'http',
+      false,
+    );
+  }
+
+  /**
    * Resolve the lane for an inbound chat message, registering it on first use.
    *
    * Lanes are cloned from the base group, so they share the folder — same
@@ -248,21 +271,13 @@ export class HttpChannel implements Channel {
     }
 
     const label = (userName ?? '').trim().slice(0, 64) || userId;
-    this.opts.registerGroup?.(jid, {
+    this.registerLane(jid, {
       ...this.baseGroup,
       name: `CoPilot — ${label}`,
       sessionKey: `${USER_SESSION_KEY_PREFIX}${userId}`,
       ipcKey: `${USER_SESSION_KEY_PREFIX}${userId}`,
       trustedSessionCommands: true,
     });
-    // isGroup=false keeps these out of the main group's activatable-group list.
-    this.opts.onChatMetadata(
-      jid,
-      new Date().toISOString(),
-      `CoPilot — ${label}`,
-      'http',
-      false,
-    );
     logger.info({ jid, userId }, 'HTTP channel: registered user lane');
     return jid;
   }
@@ -371,11 +386,11 @@ export class HttpChannel implements Channel {
     // and CoPilot's own route is scope-checked — a stronger guarantee than the
     // is_from_me flag this would otherwise require.
     this.baseGroup = { ...group, trustedSessionCommands: true };
-    this.opts.registerGroup?.(COPILOT_JID, this.baseGroup);
+    this.registerLane(COPILOT_JID, this.baseGroup);
 
     // Investigation lane: same folder and mounts, separate ephemeral session.
     // No trustedSessionCommands — nothing types slash commands at it.
-    this.opts.registerGroup?.(COPILOT_INVESTIGATE_JID, {
+    this.registerLane(COPILOT_INVESTIGATE_JID, {
       ...group,
       name: 'CoPilot Investigations',
       sessionKey: 'copilot-investigate',
@@ -390,14 +405,6 @@ export class HttpChannel implements Channel {
     );
     // Don't hold the process open just to run the sweep.
     this.sweepTimer.unref?.();
-
-    this.opts.onChatMetadata(
-      COPILOT_JID,
-      new Date().toISOString(),
-      'CoPilot',
-      'http',
-      false,
-    );
 
     this.server = http.createServer((req, res) => {
       if (req.method === 'GET' && req.url === '/health') {

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -688,6 +688,47 @@ describe('session provider', () => {
   });
 });
 
+// --- messages require a chat row ---
+
+describe('storeMessage foreign key', () => {
+  it('rejects a message for a chat that was never registered', () => {
+    // messages.chat_jid is a FK into chats(jid) and foreign keys are enforced.
+    // A lane registered as a group but missing its chat row therefore throws
+    // on the first inbound message — inside the request handler, before any
+    // response is written, so the caller sees the connection close.
+    expect(() =>
+      storeMessage({
+        id: 'investigate-1',
+        chat_jid: 'http:copilot:investigate',
+        sender: 'copilot-webhook',
+        sender_name: 'CoPilot',
+        content: 'investigate alert 1',
+        timestamp: '100',
+      }),
+    ).toThrow();
+  });
+
+  it('accepts it once the chat row exists', () => {
+    storeChatMetadata(
+      'http:copilot:investigate',
+      '100',
+      'CoPilot Investigations',
+      'http',
+      false,
+    );
+    expect(() =>
+      storeMessage({
+        id: 'investigate-1',
+        chat_jid: 'http:copilot:investigate',
+        sender: 'copilot-webhook',
+        sender_name: 'CoPilot',
+        content: 'investigate alert 1',
+        timestamp: '100',
+      }),
+    ).not.toThrow();
+  });
+});
+
 // --- session context size ---
 
 describe('session usage', () => {


### PR DESCRIPTION
**Regression from #12. Alert investigations have been failing since it merged.**

## Symptom

CoPilot's "Investigate with AI Analyst" button returned:

```
Failed to send POST request to Talon /investigate with error:
('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

while the AI Analyst **chat kept working** over the same host, port and connector row — which is what made it look like a network fault rather than a bug.

## Cause

```sql
FOREIGN KEY (chat_jid) REFERENCES chats(jid)
```

`messages.chat_jid` is a foreign key into `chats(jid)`, and better-sqlite3 enforces foreign keys by default (`PRAGMA foreign_keys = 1`).

#12 registered the investigation lane as a *group* but never created its *chat* row — `onChatMetadata` was only ever called for `COPILOT_JID`. So the first message on that lane failed the constraint:

```
FOREIGN KEY constraint failed
```

The `/investigate` handler calls `this.opts.onMessage(...)` **before** `res.writeHead(202)`, so the throw escaped with no response written and the socket closed. Hence a TCP-level symptom for what is actually a database constraint violation.

The chat lane was unaffected because `onChatMetadata(COPILOT_JID, …)` had been called at connect since long before the lane work. Per-user lanes from #13 were also unaffected — `ensureUserLane` happened to call `onChatMetadata` itself.

## Fix

Registering a lane's group entry and creating its chat row are now a single operation, `registerLane()`, used by both built-in lanes and by every per-user lane. Keeping the two writes together is the point: a lane missing its chat row is not a degraded lane, it is one that silently drops every message it receives, and the failure surfaces nowhere near its cause.

## Tests

447 pass, up from 443:

- `storeMessage` rejects a message for a chat that was never registered, and accepts it once the row exists — documents the invariant that caused this.
- `registerLane` performs both writes.
- Every user lane gets a chat row.

## Deploying

```bash
cd /path/to/talon
git pull
npm run build
sudo systemctl restart talon
```

No migration, no image rebuild. Existing deployments need nothing else — the missing `chats` row is created at connect.

Verify:

```bash
curl -s -H "x-api-key: $HTTP_API_KEY" localhost:3100/health
# then trigger an investigation from CoPilot; expect 202, not a closed connection
```

Refs socfortress/CoPilot#1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fFbajcAEwjtuZWAVT3Xg9
